### PR TITLE
Added --ignore-invalid-files command and better error message for invalid inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# Version 1.0.0
+# Version 0.5.0
 
 * Add support for enterococcus faecalis from Pointfinder database.
 * Add support for scanning against the PlasmidFinder database.
 * Upgraded the testing package to use [Green test runner](https://github.com/CleanCut/green).
-* Added Detailed_Summary table which combines results from Resfinder, Pointfinder (optional), and Plasmidfinder. 
+* Added Detailed_Summary table which combines results from Resfinder, Pointfinder (optional), and Plasmidfinder.
+* Added `--ignore-invalid-files` command and check for duplicate sequence ids.
 
 # Version 0.4.0
 

--- a/staramr/blast/BlastHandler.py
+++ b/staramr/blast/BlastHandler.py
@@ -4,6 +4,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from os import path
 from typing import Dict, List
+import re
 
 from Bio.Blast.Applications import NcbiblastnCommandline
 
@@ -107,7 +108,7 @@ class BlastHandler:
             os.symlink(path.abspath(file), destination)
             db_files.append(destination)
 
-            future_makeblastdbs.append(self._thread_pool_executor.submit(self._make_blast_db, destination))
+            future_makeblastdbs.append(self._thread_pool_executor.submit(self._make_blast_db, destination, file))
 
         # Blocks until all blast dbs are made. If an exception is raised, will raise same exception
         try:
@@ -190,7 +191,7 @@ class BlastHandler:
                 future_blast.result()
             return self._get_blast_map('pointfinder')
         else:
-            raise Exception("Error, pointfinder has not been configured")
+            raise Exception('Error, pointfinder has not been configured')
 
     def _launch_blast(self, query, db, output) -> None:
         blast_out_format = '"6 ' + ' '.join(self.BLAST_COLUMNS) + '"'
@@ -200,7 +201,13 @@ class BlastHandler:
         if stderr:
             raise Exception("error with [" + str(blastn_command) + "], stderr=" + stderr)
 
-    def _make_blast_db(self, path: str) -> None:
+    def _make_blast_db(self, path: str, file: str) -> None:
         command = ['makeblastdb', '-in', path, '-dbtype', 'nucl', '-parse_seqids']
         logger.debug(' '.join(command))
-        subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        try:
+            subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as e:
+            err_msg = str(e.stderr.strip())
+            err_msg = re.findall('REF\|(.*?)\'', err_msg)[0]
+            raise Exception('Error, file {} contains duplicate sequence ID {}'.format(file, err_msg))
+            

--- a/staramr/blast/BlastHandler.py
+++ b/staramr/blast/BlastHandler.py
@@ -195,9 +195,10 @@ class BlastHandler:
 
     def _launch_blast(self, query, db, output) -> None:
         blast_out_format = '"6 ' + ' '.join(self.BLAST_COLUMNS) + '"'
+
         blastn_command = NcbiblastnCommandline(query=query, db=db, evalue=0.001, outfmt=blast_out_format, out=output)
-        logger.debug(blastn_command)
         stdout, stderr = blastn_command()
+
         if stderr:
             raise Exception("error with [" + str(blastn_command) + "], stderr=" + stderr)
 
@@ -209,5 +210,4 @@ class BlastHandler:
         except subprocess.CalledProcessError as e:
             err_msg = str(e.stderr.strip())
             err_msg = re.findall('REF\|(.*?)\'', err_msg)[0]
-            raise Exception('Error, file {} contains duplicate sequence ID {}'.format(file, err_msg))
-            
+            raise Exception('Could not run makeblastdb on file {}, error {}'.format(file, err_msg))

--- a/staramr/blast/results/plasmidfinder/PlasmidfinderHitHSP.py
+++ b/staramr/blast/results/plasmidfinder/PlasmidfinderHitHSP.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import pandas as pd
+from typing import List
 
 from staramr.blast.results.AMRHitHSP import AMRHitHSP
 
@@ -25,7 +26,7 @@ class PlasmidfinderHitHSP(AMRHitHSP):
         logger.debug("record=%s", self._blast_record)
 
         splitList = re.split('_', self.get_amr_gene_id())
-        re_search = list(filter(None, splitList))
+        re_search = list(filter(None, splitList)) # type: List[str]
 
         if not re_search:
             raise Exception("Could not split up seq name for [" + self.get_amr_gene_id() + "]")

--- a/staramr/detection/AMRDetection.py
+++ b/staramr/detection/AMRDetection.py
@@ -138,7 +138,6 @@ class AMRDetection:
         for file in files:
             # Will raise an error if the input returns an empty generator on non-FASTA files, returns a boolean
             validInput = any(SeqIO.parse(file, "fasta"))
-            logger.debug("validInput is %s", validInput)
 
             if not validInput:
                 if ignore_invalid_files:
@@ -148,7 +147,7 @@ class AMRDetection:
                 else:
                     raise Exception('File {} is invalid, please use --ignore-invalid-files to skip over invalid input files'.format(file))
 
-        # Check to see if the empty file is not the only file in the directory
+        # Check to see if the invalid file is not the only file in the directory
         if total_files == invalid_files:
             raise Exception('Cannot produce output due to no valid input files')
 

--- a/staramr/detection/AMRDetection.py
+++ b/staramr/detection/AMRDetection.py
@@ -7,7 +7,7 @@ from staramr.blast.resfinder.ResfinderBlastDatabase import ResfinderBlastDatabas
 from staramr.blast.plasmidfinder.PlasmidfinderBlastDatabase import PlasmidfinderBlastDatabase
 from staramr.blast.results.BlastResultsParser import BlastResultsParser
 from Bio import SeqIO
-import logging
+import logging, copy
 
 import pandas as pd
 from pandas import DataFrame
@@ -104,7 +104,8 @@ class AMRDetection:
         :return: None
         """
 
-        files = self._validate_files(files, ignore_invalid_files)
+        files_copy = copy.deepcopy(files)
+        files = self._validate_files(files_copy, ignore_invalid_files)
                    
         self._amr_detection_handler.run_blasts(files)
 
@@ -132,7 +133,6 @@ class AMRDetection:
                                                                              
     def _validate_files(self, files: List[str], ignore_invalid_files: bool) -> List[str]:
         total_files = len(files)
-        invalid_files = 0
         removeable_files = []
 
         for file in files:
@@ -142,13 +142,12 @@ class AMRDetection:
             if not validInput:
                 if ignore_invalid_files:
                         logger.warning('--ignore-invalid-files is set, skipping file {}'.format(file))
-                        invalid_files +=1
                         removeable_files.append(file)
                 else:
                     raise Exception('File {} is invalid, please use --ignore-invalid-files to skip over invalid input files'.format(file))
 
         # Check to see if the invalid file is not the only file in the directory
-        if total_files == invalid_files:
+        if total_files == len(removeable_files):
             raise Exception('Cannot produce output due to no valid input files')
 
         # Remove the skipped files

--- a/staramr/detection/AMRDetection.py
+++ b/staramr/detection/AMRDetection.py
@@ -8,6 +8,7 @@ from staramr.blast.plasmidfinder.PlasmidfinderBlastDatabase import Plasmidfinder
 from staramr.blast.results.BlastResultsParser import BlastResultsParser
 from Bio import SeqIO
 import logging, copy, os
+from collections import Counter
 
 import pandas as pd
 from pandas import DataFrame
@@ -162,6 +163,25 @@ class AMRDetection:
         if ignore_invalid_files:
             for file in removeable_files:
                 files.remove(file)
+
+        # Check if there are any duplicate sequence id's in the valid files
+        for file in files:
+            record = []
+            # Store all the sequence id's in a list
+            for sequence in SeqIO.parse(file, "fasta"):
+                record.append(sequence.id)
+
+            duplicates = []
+
+            # Each sequence contains a tuple (sequence id, frequency)
+            for sequence in (Counter(record)).items():
+                if sequence[1] > 1:
+                    # We want the sequence id's that are duplicates
+                    duplicates.append(sequence[0])
+
+            # Raise an error if there's a duplicate in the file
+            if len(duplicates) > 0:
+                raise Exception('File {} contains the following duplicate sequence IDs: {}'.format(file, duplicates))
 
         return files
 

--- a/staramr/detection/AMRDetection.py
+++ b/staramr/detection/AMRDetection.py
@@ -154,6 +154,24 @@ class AMRDetection:
                             removeable_files.append(file)
                     else:
                         raise Exception('File {} is invalid, please use --ignore-invalid-files to skip over invalid input files'.format(file))
+                else:
+                    # Check if there are any duplicate sequence id's in the valid files
+                    record = []
+                    # Store all the sequence id's in a list
+                    for sequence in SeqIO.parse(file, "fasta"):
+                        record.append(sequence.id)
+
+                    duplicates = []
+
+                    # Each sequence contains a tuple (sequence id, frequency)
+                    for sequence in (Counter(record)).items():
+                        if sequence[1] > 1:
+                            # We want the sequence id's that are duplicates
+                            duplicates.append(sequence[0])
+
+                    # Raise an error if there's any duplicates in the file
+                    if len(duplicates) > 0:
+                        raise Exception('File {} contains the following duplicate sequence IDs: {}'.format(file, duplicates))
             
         # Check to see if the invalid file is not the only file in the directory
         if total_files == len(removeable_files):
@@ -163,25 +181,6 @@ class AMRDetection:
         if ignore_invalid_files:
             for file in removeable_files:
                 files.remove(file)
-
-        # Check if there are any duplicate sequence id's in the valid files
-        for file in files:
-            record = []
-            # Store all the sequence id's in a list
-            for sequence in SeqIO.parse(file, "fasta"):
-                record.append(sequence.id)
-
-            duplicates = []
-
-            # Each sequence contains a tuple (sequence id, frequency)
-            for sequence in (Counter(record)).items():
-                if sequence[1] > 1:
-                    # We want the sequence id's that are duplicates
-                    duplicates.append(sequence[0])
-
-            # Raise an error if there's a duplicate in the file
-            if len(duplicates) > 0:
-                raise Exception('File {} contains the following duplicate sequence IDs: {}'.format(file, duplicates))
 
         return files
 

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -68,7 +68,6 @@ class AMRDetectionSummary:
         negative_entries = None
 
         if len(negative_res_names_set) != len(names_set) or resistance_frame.empty:
-            logger.debug("Went here")
             negative_resistance_entries = pd.DataFrame([[x, 'None', 'Sensitive'] for x in negative_res_names_set],
                                                        columns=('Isolate ID', 'Gene', 'Predicted Phenotype')).set_index('Isolate ID')
             negative_resistance_entries['Data Type']='Resistance'

--- a/staramr/subcommand/Search.py
+++ b/staramr/subcommand/Search.py
@@ -61,19 +61,19 @@ class Search(SubCommand):
         arg_parser.add_argument('--pointfinder-organism', action='store', dest='pointfinder_organism', type=str,
                                 help='The organism to use for pointfinder {' + ', '.join(
                                     PointfinderBlastDatabase.get_available_organisms()) + '}. Defaults to disabling search for point mutations. [None].',
-                                default=None,
-                                required=False)
+                                default=None, required=False)
         arg_parser.add_argument('--plasmidfinder-database-type', action='store', dest='plasmidfinder_database_type', type=str,
                                 help='The database type to use for plasmidfinder {' + ', '.join(
                                     PlasmidfinderBlastDatabase.get_available_databases()) + '}. Defaults to using all available database types to search for plasmids. [None].',
-                                default=None,
-                                required=False)
+                                default=None, required=False)
         arg_parser.add_argument('-d', '--database', action='store', dest='database', type=str,
                                 help='The directory containing the resfinder/pointfinder databases [' + self._default_database_dir + '].',
                                 default=self._default_database_dir, required=False)
         arg_parser.add_argument('-n', '--nprocs', action='store', dest='nprocs', type=int,
                                 help='The number of processing cores to use [' + str(cpu_count) + '].',
                                 default=cpu_count, required=False)
+        arg_parser.add_argument('--ignore-invalid-files', action='store_true', dest='ignore_valid_files',
+                                help='Skip over invalid input files', required=False)
 
         threshold_group = arg_parser.add_argument_group('BLAST Thresholds')
         threshold_group.add_argument('--pid-threshold', action='store', dest='pid_threshold', type=float,
@@ -207,7 +207,7 @@ class Search(SubCommand):
 
     def _generate_results(self, database_repos, resfinder_database, pointfinder_database, plasmidfinder_database, nprocs, include_negatives,
                           include_resistances, hits_output, pid_threshold, plength_threshold_resfinder,
-                          plength_threshold_pointfinder, plength_threshold_plasmidfinder, report_all_blast, genes_to_exclude, files):
+                          plength_threshold_pointfinder, plength_threshold_plasmidfinder, report_all_blast, genes_to_exclude, files, ignore_invalid_files):
         """
         Runs AMR detection and generates results.
         :param database_repos: The database repos object.
@@ -225,6 +225,7 @@ class Search(SubCommand):
         :param report_all_blast: Whether or not to report all BLAST results.
         :param genes_to_exclude: A list of gene IDs to exclude from the results.
         :param files: The list of files to scan.
+        :param ignore_invalid_files: Skips over invalid input files
         :return: A dictionary containing the results as dict['results'] and settings as dict['settings'].
         """
         results = {'results': None, 'settings': None}
@@ -244,7 +245,7 @@ class Search(SubCommand):
                                                         output_dir=hits_output,
                                                         genes_to_exclude=genes_to_exclude)
             amr_detection.run_amr_detection(files, pid_threshold, plength_threshold_resfinder,
-                                            plength_threshold_pointfinder, plength_threshold_plasmidfinder, report_all_blast)
+                                            plength_threshold_pointfinder, plength_threshold_plasmidfinder, report_all_blast, ignore_invalid_files)
 
             results['results'] = amr_detection
 
@@ -411,7 +412,8 @@ class Search(SubCommand):
                                          plength_threshold_plasmidfinder=args.plength_threshold_plasmidfinder,
                                          report_all_blast=args.report_all_blast,
                                          genes_to_exclude=exclude_genes,
-                                         files=args.files)
+                                         files=args.files,
+                                         ignore_invalid_files=args.ignore_valid_files)
         amr_detection = results['results']
         settings = results['settings']
 


### PR DESCRIPTION
Based on issue #25, #20  

## Problem
There isn't a good error message for when input files are valid or empty. Also, the error message for handling duplicate sequence ID's isn't efficient.

## Solution
Use the [SeqIO library](https://biopython.org/wiki/SeqIO) to handle file validation. 

## Implementation

- Create a method to validate the input files and add additional logic for when the `--ignore-valid-files` is used before it runs BLAST.
- Update the error message to include the file name and sequence ID if there are duplicates

## Testing

- Manually done through the command line to see if it gives out my expected output

- Realized there was an edge case where I have to handle if the invalid input file was the only file in the directory as well as skipping ignored files in the final output.

- Cases that I have tried in the following below:

|            Input           | Use Ignore Files Command |         Expected Behaviour         |
|:--------------------------:|:------------------------:|:----------------------------------:|
| 1 Empty File               |            No            | Raise Assertion for invalid file   |
| 1 Empty File               |            Yes           | Raise Assertion for no valid files |
| 1 Empty File with Spaces   |            No            | Raise Assertion for invalid file   |
| 1 Empty File with Spaces   |            Yes           | Raise Assertion for invalid file   |
| 1 Empty File, 1 Valid File |            No            | Raise Assertion for invalid file   |
| 1 Empty File, 1 Valid File |            Yes           | Generates Output                   |
| 1 Empty File, 1 Valid File (with 2 records) |            Yes           | Generates Output                   |