### PR TITLE
Fixed exclude phenotype column command

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,11 +432,13 @@ Phenotype/drug resistance predictions are provided with support from the NARMS/C
 
 # Citations
 
-If you find `staramr` useful, please consider citing this GitHub repository (https://github.com/phac-nml/staramr) as well as the original ResFinder and PointFinder publications.
+If you find `staramr` useful, please consider citing this GitHub repository (https://github.com/phac-nml/staramr) as well as the original ResFinder, PointFinder, and PlasmidFinder publications.
 
 > **Zankari E, Hasman H, Cosentino S, Vestergaard M, Rasmussen S, Lund O, Aarestrup FM, Larsen MV**. 2012. Identification of acquired antimicrobial resistance genes. J. Antimicrob. Chemother. 67:2640–2644. doi: [10.1093/jac/dks261][resfinder-cite]
 
 > **Zankari E, Allesøe R, Joensen KG, Cavaco LM, Lund O, Aarestrup F**. PointFinder: a novel web tool for WGS-based detection of antimicrobial resistance associated with chromosomal point mutations in bacterial pathogens. J Antimicrob Chemother. 2017; 72(10): 2764–8. doi: [10.1093/jac/dkx217][pointfinder-cite]
+
+> **Carattoli A, Zankari E, Garcia-Fernandez A, Voldby Larsen M, Lund O, Villa L, Aarestrup FM, Hasman H**. PlasmidFinder and pMLST: in silico detection and typing of plasmids. Antimicrob. Agents Chemother. 2014. April 28th. doi: [10.1128/AAC.02412-14][plasmidfinder-cite]
 
 # Legal
 
@@ -459,6 +461,7 @@ specific language governing permissions and limitations under the License.
 [resfinder-web]: https://cge.cbs.dtu.dk/services/ResFinder/
 [resfinder-cite]: https://dx.doi.org/10.1093/jac/dks261
 [pointfinder-cite]: https://doi.org/10.1093/jac/dkx217
+[plasmidfinder-cite]: https://doi.org/10.1128/AAC.02412-14
 [Bioconda]: https://bioconda.github.io/
 [requirements.txt]: requirements.txt
 [resfinder-git]: https://bitbucket.org/genomicepidemiology/resfinder

--- a/staramr/detection/AMRDetectionResistance.py
+++ b/staramr/detection/AMRDetectionResistance.py
@@ -5,6 +5,10 @@ from staramr.blast.results.plasmidfinder.BlastResultsParserPlasmidfinderResistan
 from staramr.detection.AMRDetection import AMRDetection
 from staramr.results.AMRDetectionSummaryResistance import AMRDetectionSummaryResistance
 
+from pandas import DataFrame
+from typing import List, Dict, Optional
+from staramr.blast.results.pointfinder.BlastResultsParserPointfinder import BlastResultsParserPointfinder
+
 """
 A Class to handle scanning files for AMR genes and also include pheneotypes/resistances in results.
 """
@@ -59,3 +63,10 @@ class AMRDetectionResistance(AMRDetection):
     def _create_amr_summary(self, files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe):
         amr_detection_summary = AMRDetectionSummaryResistance(files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe)
         return amr_detection_summary.create_summary(self._include_negative_results)
+
+    def _create_detailed_amr_summary(self, files: List[str], resfinder_dataframe: DataFrame,
+                                     pointfinder_dataframe: Optional[BlastResultsParserPointfinder],
+                                     plasmidfinder_dataframe: DataFrame) -> DataFrame:
+        amr_detection_summary = AMRDetectionSummaryResistance(files, resfinder_dataframe,
+                                                    pointfinder_dataframe, plasmidfinder_dataframe)
+        return amr_detection_summary.create_detailed_summary(self._include_negative_results)

--- a/staramr/results/AMRDetectionSummaryResistance.py
+++ b/staramr/results/AMRDetectionSummaryResistance.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
 import pandas as pd
+from pandas import DataFrame
+from typing import List
 
 from staramr.results.AMRDetectionSummary import AMRDetectionSummary
 
@@ -44,12 +46,17 @@ class AMRDetectionSummaryResistance(AMRDetectionSummary):
             .aggregate(self._aggregate_gene_phenotype)
         return df_summary[['Gene', 'Predicted Phenotype']]
 
-    def _include_negatives(self, df):
-        result_names_set = set(df.index.tolist())
-        names_set = set(self._names)
+    def get_detailed_negative_columns(self):
+        return ['Isolate ID', 'Gene', 'Predicted Phenotype', 'Start', 'End']
 
-        negative_names_set = names_set - result_names_set
-        negative_entries = pd.DataFrame([[x, 'None', 'Sensitive'] for x in negative_names_set],
-                                        columns=('Isolate ID', 'Gene', 'Predicted Phenotype')).set_index(
-            'Isolate ID')
-        return df.append(negative_entries, sort=True)
+    def get_summary_empty_values(self):
+        return {'Genotype': 'None', 'Predicted Phenotype': 'Sensitive'}
+
+    def get_summary_resistance_columns(self):
+        return ['Genotype', 'Predicted Phenotype', 'Plasmid Genes']
+
+    def get_detailed_summary_columns(self):
+        return ['Gene', 'Predicted Phenotype', '%Identity', '%Overlap', 'HSP Length/Total Length', 'Contig', 'Start', 'End', 'Accession', 'Data Type']
+
+    def include_phenotype(self):
+        return True

--- a/staramr/results/AMRDetectionSummaryResistance.py
+++ b/staramr/results/AMRDetectionSummaryResistance.py
@@ -46,17 +46,17 @@ class AMRDetectionSummaryResistance(AMRDetectionSummary):
             .aggregate(self._aggregate_gene_phenotype)
         return df_summary[['Gene', 'Predicted Phenotype']]
 
-    def get_detailed_negative_columns(self):
+    def _get_detailed_negative_columns(self):
         return ['Isolate ID', 'Gene', 'Predicted Phenotype', 'Start', 'End']
 
-    def get_summary_empty_values(self):
+    def _get_summary_empty_values(self):
         return {'Genotype': 'None', 'Predicted Phenotype': 'Sensitive'}
 
-    def get_summary_resistance_columns(self):
+    def _get_summary_resistance_columns(self):
         return ['Genotype', 'Predicted Phenotype', 'Plasmid Genes']
 
-    def get_detailed_summary_columns(self):
+    def _get_detailed_summary_columns(self):
         return ['Gene', 'Predicted Phenotype', '%Identity', '%Overlap', 'HSP Length/Total Length', 'Contig', 'Start', 'End', 'Accession', 'Data Type']
 
-    def include_phenotype(self):
+    def _include_phenotype(self):
         return True

--- a/staramr/tests/unit/results/test_AMRDetectionSummary.py
+++ b/staramr/tests/unit/results/test_AMRDetectionSummary.py
@@ -4,6 +4,7 @@ import pandas as pd
 import logging
 
 from staramr.results.AMRDetectionSummary import AMRDetectionSummary
+from staramr.results.AMRDetectionSummaryResistance import AMRDetectionSummaryResistance
 
 logger = logging.getLogger('AMRDetectionSummaryTest')
 
@@ -412,7 +413,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('blaIMP-42, gyrA', summary['Genotype'].iloc[0], 'Genes not equal')
 
     def testDetailedSummary_noPlasmid_noPoint(self):
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'))
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'))
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -434,7 +435,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         plasmid_table['Isolate ID'] = 'file1'
         plasmid_table = plasmid_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), plasmidfinder_dataframe=plasmid_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), plasmidfinder_dataframe=plasmid_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -455,7 +456,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         point_table = self.pointfinder_table
         point_table = point_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), pointfinder_dataframe=point_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), pointfinder_dataframe=point_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -485,7 +486,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         plasmid_table['Isolate ID'] = 'file1'
         plasmid_table = plasmid_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), pointfinder_dataframe=point_table, plasmidfinder_dataframe=plasmid_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), pointfinder_dataframe=point_table, plasmidfinder_dataframe=plasmid_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -507,7 +508,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         plasmid_table['Isolate ID'] = 'file1'
         plasmid_table = plasmid_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), plasmidfinder_dataframe=plasmid_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), plasmidfinder_dataframe=plasmid_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -528,7 +529,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         point_table = self.pointfinder_table
         point_table = point_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), pointfinder_dataframe=point_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), pointfinder_dataframe=point_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -553,7 +554,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         plasmid_table['Isolate ID'] = 'file1'
         plasmid_table = plasmid_table.set_index('Isolate ID')
 
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), pointfinder_dataframe=point_table, plasmidfinder_dataframe=plasmid_table)
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table1.set_index('Isolate ID'), pointfinder_dataframe=point_table, plasmidfinder_dataframe=plasmid_table)
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -575,7 +576,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('', detailed_summary['Predicted Phenotype'].iloc[2], 'Predicted Phenotype not equal')
 
     def testDetailedSummary_noFinders(self):
-        amr_detection_summary = AMRDetectionSummary(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), self.pointfinder_table_empty.set_index('Isolate ID'), self.plasmidfinder_table_empty.set_index('Isolate ID'))
+        amr_detection_summary = AMRDetectionSummaryResistance(self.resfinder_table1_files, self.resfinder_table_empty.set_index('Isolate ID'), self.pointfinder_table_empty.set_index('Isolate ID'), self.plasmidfinder_table_empty.set_index('Isolate ID'))
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 
@@ -593,7 +594,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('Sensitive', detailed_summary['Predicted Phenotype'].iloc[1], 'Predicted Phenotype not equal')
 
     def testDetailedSummary_multiFiles(self):
-        amr_detection_summary = AMRDetectionSummary(self.detailed_summary_multi_files, self.resfinder_table_mult_file.set_index('Isolate ID'), self.pointfinder_table_multiple_gene.set_index('Isolate ID'), self.plasmidfinder_table_mult_file.set_index('Isolate ID'))
+        amr_detection_summary = AMRDetectionSummaryResistance(self.detailed_summary_multi_files, self.resfinder_table_mult_file.set_index('Isolate ID'), self.pointfinder_table_multiple_gene.set_index('Isolate ID'), self.plasmidfinder_table_mult_file.set_index('Isolate ID'))
 
         detailed_summary = amr_detection_summary.create_detailed_summary()
 


### PR DESCRIPTION
Based on Issue #65 

## Problem
When you include the `--exclude-resistance-phenotypes` in the command line, the Predicted Phenotypes Column is still included in the summary and detailed_summary file

## Solution
Take advantage of _polymorphism_ and _overriding_ to dynamically remove the Predicted Phenotypes Column

## Implementation
Create getter methods to return the proper column names and values

## Testing
Ran through the staramr tests and refactored the unit tests to use the `AMRDetectionSummaryResistance` method rather than the `AMRDetectionSummary`