### PR TITLE
Updated Scheme and Sequence type to summary and optimized MLST to use thread pools

### DIFF
--- a/staramr/detection/AMRDetection.py
+++ b/staramr/detection/AMRDetection.py
@@ -59,16 +59,16 @@ class AMRDetection:
 
     def _create_amr_summary(self, files: List[str], resfinder_dataframe: DataFrame,
                             pointfinder_dataframe: Optional[BlastResultsParserPointfinder],
-                            plasmidfinder_dataframe: DataFrame) -> DataFrame:
+                            plasmidfinder_dataframe: DataFrame, mlst_dataframe: DataFrame) -> DataFrame:
         amr_detection_summary = AMRDetectionSummary(files, resfinder_dataframe,
-                                                    pointfinder_dataframe, plasmidfinder_dataframe)
+                                                    pointfinder_dataframe, plasmidfinder_dataframe, mlst_dataframe)
         return amr_detection_summary.create_summary(self._include_negative_results)
 
     def _create_detailed_amr_summary(self, files: List[str], resfinder_dataframe: DataFrame,
                                      pointfinder_dataframe: Optional[BlastResultsParserPointfinder],
-                                     plasmidfinder_dataframe: DataFrame) -> DataFrame:
+                                     plasmidfinder_dataframe: DataFrame, mlst_dataframe: DataFrame) -> DataFrame:
         amr_detection_summary = AMRDetectionSummary(files, resfinder_dataframe,
-                                                    pointfinder_dataframe, plasmidfinder_dataframe)
+                                                    pointfinder_dataframe, plasmidfinder_dataframe, mlst_dataframe)
         return amr_detection_summary.create_detailed_summary(self._include_negative_results)
 
     def _create_resfinder_dataframe(self, resfinder_blast_map: Dict, pid_threshold: float, plength_threshold: int,
@@ -107,15 +107,18 @@ class AMRDetection:
 
         columns = ['Isolate ID', 'Scheme', 'Sequence Type']
         curr_data = []
-        max_columns = 0;
+        max_columns = 0
+        extension = None
 
         mlst_split = mlst_data.splitlines()
 
         # Parse and format the current row
         for row in mlst_split:
-            array_format = re.split('\t', row);
+            array_format = re.split('\t', row)
             num_columns = len(array_format)
-            array_format[0] = path.basename(array_format[0])
+
+            # We want the file name without the extension
+            array_format[0] = path.basename(path.splitext(array_format[0])[0])
 
             if max_columns < num_columns:
                 max_columns = num_columns
@@ -174,11 +177,12 @@ class AMRDetection:
                                                                              plength_threshold_pointfinder, report_all)
 
         self._summary_dataframe = self._create_amr_summary(files, self._resfinder_dataframe,
-                                                           self._pointfinder_dataframe, self._plasmidfinder_dataframe)
+                                                           self._pointfinder_dataframe, self._plasmidfinder_dataframe, self._mlst_dataframe)
 
         self._detailed_summary_dataframe = self._create_detailed_amr_summary(files, self._resfinder_dataframe,
                                                                              self._pointfinder_dataframe,
-                                                                             self._plasmidfinder_dataframe)
+                                                                             self._plasmidfinder_dataframe,
+                                                                             self._mlst_dataframe)
 
     def _validate_files(self, files: List[str], ignore_invalid_files: bool) -> List[str]:
         total_files = len(files)

--- a/staramr/detection/AMRDetectionResistance.py
+++ b/staramr/detection/AMRDetectionResistance.py
@@ -64,14 +64,14 @@ class AMRDetectionResistance(AMRDetection):
                                                                          genes_to_exclude=self._genes_to_exclude)
         return plasmidfinder_parser.parse_results()
 
-    def _create_amr_summary(self, files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe):
+    def _create_amr_summary(self, files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe, mlst_dataframe):
         amr_detection_summary = AMRDetectionSummaryResistance(files, resfinder_dataframe, pointfinder_dataframe,
-                                                              plasmidfinder_dataframe)
+                                                              plasmidfinder_dataframe, mlst_dataframe)
         return amr_detection_summary.create_summary(self._include_negative_results)
 
     def _create_detailed_amr_summary(self, files: List[str], resfinder_dataframe: DataFrame,
                                      pointfinder_dataframe: Optional[BlastResultsParserPointfinder],
-                                     plasmidfinder_dataframe: DataFrame) -> DataFrame:
+                                     plasmidfinder_dataframe: DataFrame, mlst_dataframe) -> DataFrame:
         amr_detection_summary = AMRDetectionSummaryResistance(files, resfinder_dataframe,
-                                                              pointfinder_dataframe, plasmidfinder_dataframe)
+                                                              pointfinder_dataframe, plasmidfinder_dataframe, mlst_dataframe)
         return amr_detection_summary.create_detailed_summary(self._include_negative_results)

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -17,7 +17,7 @@ class AMRDetectionSummary:
     FLOAT_DECIMALS = 2
 
     def __init__(self, files, resfinder_dataframe: DataFrame, pointfinder_dataframe=None,
-                 plasmidfinder_dataframe=None) -> None:
+                 plasmidfinder_dataframe=None, mlst_dataframe=None) -> None:
         """
         Constructs an object for summarizing AMR detection results.
         :param files: The list of genome files we have scanned against.
@@ -27,6 +27,7 @@ class AMRDetectionSummary:
         self._names = [path.splitext(path.basename(x))[0] for x in files]
         self._resfinder_dataframe = resfinder_dataframe
         self._plasmidfinder_dataframe = plasmidfinder_dataframe
+        self._mlst_dataframe = mlst_dataframe
 
         if pointfinder_dataframe is not None:
             self._has_pointfinder = True
@@ -125,6 +126,7 @@ class AMRDetectionSummary:
         """
         resistance_frame = self._resfinder_dataframe
         plasmid_frame = self._plasmidfinder_dataframe
+        mlst_frame = self._mlst_dataframe
 
         if self._has_pointfinder:
             resistance_frame = resistance_frame.append(self._pointfinder_dataframe, sort=True)
@@ -150,6 +152,10 @@ class AMRDetectionSummary:
 
             resistance_frame = resistance_frame.fillna(value=fill_values)
             resistance_frame = resistance_frame.reindex(columns=resistance_columns)
+
+        if mlst_frame is not None:
+            mlst_merging_frame = mlst_frame[['Scheme', 'Sequence Type']]
+            resistance_frame = resistance_frame.merge(mlst_merging_frame, on='Isolate ID', how='left')
 
         return resistance_frame.sort_index()
 

--- a/staramr/results/AMRDetectionSummaryResistance.py
+++ b/staramr/results/AMRDetectionSummaryResistance.py
@@ -9,7 +9,7 @@ Summarizes both ResFinder and PointFinder database results into a single table.
 
 class AMRDetectionSummaryResistance(AMRDetectionSummary):
 
-    def __init__(self, files, resfinder_dataframe, pointfinder_dataframe=None, plasmidfinder_dataframe=None):
+    def __init__(self, files, resfinder_dataframe, pointfinder_dataframe=None, plasmidfinder_dataframe=None, mlst_dataframe=None):
         """
         Creates a new AMRDetectionSummaryResistance.
         :param files: The list of genome files we have scanned against.
@@ -17,7 +17,7 @@ class AMRDetectionSummaryResistance(AMRDetectionSummary):
         :param pointfinder_dataframe: The pd.DataFrame containing the PointFinder results.
         :param plasmidfinder_dataframe: The pd.DataFrame containing the PlasmidFinder results.
         """
-        super().__init__(files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe)
+        super().__init__(files, resfinder_dataframe, pointfinder_dataframe, plasmidfinder_dataframe, mlst_dataframe)
 
     def _aggregate_gene_phenotype(self, dataframe):
         flattened_phenotype_list = [y.strip() for x in dataframe['Predicted Phenotype'].tolist() for y in


### PR DESCRIPTION
Based on Issue #81 and #79  

## Problem
Based on the issue #81 , since the `mlst --threads` command wasn't doing what we expected to do, there was still a huge bottleneck within the code since each file has to go through mlst one at a time, it wasn't utilizing it resources enough.

## Solution
Partition the files evenly based on the number of threads available, instantiate the threads in a thread pool and assign an mlst instance to a thread.

## Implementation
The implementation is pretty similar to how blast does it. It uses the `ThreadPoolExecutor` class to assign the thread to a process.

## Testing
Been checking the `time` system in `staramr` to see if there was a significant performance change given 50 files and use the `top` command to see if the CPU's were being utilized.
