### PR TITLE
Doc/installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ install:
   - hash -r
   - conda update -q -y conda
   - conda info -a
-  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst pandas==0.25.3
+  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
   - source activate test-environment
   - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS
   - pip install mypy==0.600
+  - pip install pandas==0.25.3
 
 script: ./scripts/mypy && python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - hash -r
   - conda update -q -y conda
   - conda info -a
-  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
+  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst pandas==0.25.3
   - source activate test-environment
   - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The easiest way to install `staramr` is through [Bioconda][bioconda].
 conda install -c bioconda staramr==0.7.1 pandas==0.25.3
 ```
 
-This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.24.0` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
+This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.25.3` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
 
 ```bash
 staramr --help

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ staramr db restore-default
 The easiest way to install `staramr` is through [Bioconda][bioconda].
 
 ```bash
-conda install -c bioconda staramr
+conda install -c bioconda staramr==0.7.1 pandas==0.25.3
 ```
 
-This will install the `staramr` Python package as well as all necessary dependencies and databases.  You can now run:
+This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.24.0` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
 
 ```bash
 staramr --help
@@ -171,7 +171,7 @@ staramr --help
 If you wish to use `staramr` in an isolated environment (in case dependencies conflict) you may alternatively install with:
 
 ```bash
-conda create -c bioconda --name staramr staramr
+conda create -c bioconda --name staramr staramr==0.7.1 pandas==0.25.3
 ```
 
 To run `staramr` in this case, you must first activate the environment.  That is:


### PR DESCRIPTION
Fixed up some documentation so that the correct version of `staramr` (with correct dependencies) get installed via conda. Partially addresses issue #115 