### PR TITLE
Doc/installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
   - source activate test-environment
   - python setup.py install
+  - pip install pandas==0.25.3
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS
   - pip install mypy==0.600
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ install:
   - hash -r
   - conda update -q -y conda
   - conda info -a
-  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst pandas==0.25.3
+  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
   - source activate test-environment
   - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS
   - pip install mypy==0.600
+  - pip install pandas==0.25.3
 
 script: ./scripts/mypy && python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
   - conda info -a
   - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
   - source activate test-environment
-  - python setup.py install
   - pip install pandas==0.25.3
+  - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS
   - pip install mypy==0.600
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,5 @@ install:
   - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS
   - pip install mypy==0.600
-  - pip install pandas==0.25.3
 
 script: ./scripts/mypy && python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - hash -r
   - conda update -q -y conda
   - conda info -a
-  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst
+  - conda create -c bioconda -c conda-forge -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION blast=2.7.1 git mlst pandas==0.25.3
   - source activate test-environment
   - python setup.py install
   - staramr db build --dir staramr/databases/data $DATABASE_COMMITS

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The easiest way to install `staramr` is through [Bioconda][bioconda].
 conda install -c bioconda staramr==0.7.1 pandas==0.25.3
 ```
 
-This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.24.0` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
+This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.25.3` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
 
 ```bash
 staramr --help

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ staramr db restore-default
 The easiest way to install `staramr` is through [Bioconda][bioconda].
 
 ```bash
-conda install -c bioconda staramr==0.7.1 pandas==0.25.3
+conda install -c bioconda staramr==0.7.1
 ```
 
-This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.25.3` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
+This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will install all necessary dependencies and databases. Once this is complete you can run:
 
 ```bash
 staramr --help
@@ -171,7 +171,7 @@ staramr --help
 If you wish to use `staramr` in an isolated environment (in case dependencies conflict) you may alternatively install with:
 
 ```bash
-conda create -c bioconda --name staramr staramr==0.7.1 pandas==0.25.3
+conda create -c bioconda --name staramr staramr==0.7.1
 ```
 
 To run `staramr` in this case, you must first activate the environment.  That is:

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ staramr db restore-default
 The easiest way to install `staramr` is through [Bioconda][bioconda].
 
 ```bash
-conda install -c bioconda staramr
+conda install -c bioconda staramr==0.7.1 pandas==0.25.3
 ```
 
-This will install the `staramr` Python package as well as all necessary dependencies and databases.  You can now run:
+This will install the `staramr` Python package at version `0.7.1` (replace with whichever version you wish to install). Bioconda will also install all necessary dependencies and databases (we use `pandas==0.24.0` since `staramr` is currently not compatible with newer versions of `pandas`).  You can now run:
 
 ```bash
 staramr --help
@@ -171,7 +171,7 @@ staramr --help
 If you wish to use `staramr` in an isolated environment (in case dependencies conflict) you may alternatively install with:
 
 ```bash
-conda create -c bioconda --name staramr staramr
+conda create -c bioconda --name staramr staramr==0.7.1 pandas==0.25.3
 ```
 
 To run `staramr` in this case, you must first activate the environment.  That is:


### PR DESCRIPTION
Fixes up `README.md` to specify that you should run `conda install staramr==0.7.1` (instead of just installing default, which will install an older version of staramr).

Also fixed tests so that they will properly work (uses pandas `0.25.3` instead of `1.0+`). The proper solution would be to update the dependencies in `setup.py`, but I didn't want to then have to make a new release.