### PR TITLE
add more species to pointfinder analysis list

### DIFF
--- a/staramr/blast/pointfinder/PointfinderBlastDatabase.py
+++ b/staramr/blast/pointfinder/PointfinderBlastDatabase.py
@@ -80,7 +80,9 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         A Class Method to get a list of organisms that are currently supported by staramr.
         :return: The list of organisms currently supported by staramr.
         """
-        return ['salmonella', 'campylobacter']
+        return ['campylobacter', 'enterococcus_faecalis', 'enterococcus_faecium','escherichia_coli',
+                'helicobacter_pylori', 'klebsiella','mycobacterium_tuberculosis','neisseria_gonorrhoeae',
+                'plasmodium_falciparum','staphylococcus_aureus', 'salmonella']
 
     @classmethod
     def get_organisms(cls, database_dir):


### PR DESCRIPTION
Hi, 
I would like to increase the number of available species used by staramr from the pointfinder DB. I simply modified the list of species in 
`staramr/blast/pointfinder/PointfinderBlastDatabase.py` and compared the output with the pointfinder webservice, which are identical all tested species.
Is there more to do as a first step to increase analysis ?
Then, I would like:
 - [ ] Implement the automatic detection of new species in the database when updated, with test for available file format 
 - [ ] Add an option to build a database from raw files which could be tranlated in the pointfinder format to be analyzed

```
    @classmethod
    def get_available_organisms(cls):
        """
        A Class Method to get a list of organisms that are currently supported by staramr.
        :return: The list of organisms currently supported by staramr.
        """
        return ['campylobacter', 'enterococcus_faecalis', 'enterococcus_faecium','escherichia_coli',
                'helicobacter_pylori', 'klebsiella','mycobacterium_tuberculosis','neisseria_gonorrhoeae',
                'plasmodium_falciparum','staphylococcus_aureus', 'salmonella']

```