### PR TITLE
Updated ecoli pointfinder gene-drug mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     * Adds the ability to handle promoters (regions with both promoter nucleotide information and non-promoter codon information)
     * Adds handling of insertions and deletions in nucleotide and codon sequence
     * Updates list of supported PointFinder species to `salmonella`, `campylobacter`, `enterococcus_faecalis`, `enterococcus_faecium`, `escherichia_coli`, `helicobacter_pylori`.
+* Switch name `e.coli` to `escherichia_coli` in PointFinder gene-drug key to match organism name in PointFinder database.
 
 # Version 0.8.0
 

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -49,71 +49,71 @@ salmonella	16S_rrsD	1065	spectinomycin
 salmonella	16S_rrsD	1192	spectinomycin
 salmonella	parC	57	None
 salmonella	acrB	171	azithromycin
-e.coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrB	136	aminocoumarin
-e.coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	56	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	57	None
-e.coli	parC	60	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	78	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	80	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	84	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	108	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	416	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	423	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	439	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	444	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	458	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	460	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	464	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	470	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	475	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	476	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	529	ciprofloxacin I/R,nalidixic acid
-e.coli	pmrA	39	colistin
-e.coli	pmrA	81	colistin
-e.coli	pmrB	161	colistin
-e.coli	folP	64	sulfisoxazole
-e.coli	rpoB	146	rifamycin
-e.coli	rpoB	513	rifamycin
-e.coli	rpoB	526	rifamycin
-e.coli	rpoB	529	rifamycin
-e.coli	rpoB	531	rifamycin
-e.coli	rpoB	533	rifamycin
-e.coli	rpoB	563	rifamycin
-e.coli	rpoB	564	rifamycin
-e.coli	rpoB	687	rifamycin
-e.coli	23S	2059	erythromycin,azithromycin
-e.coli	16S_rrsB	523	streptomycin
-e.coli	16S_rrsB	527	streptomycin
-e.coli	16S_rrsB	528	streptomycin
-e.coli	16S_rrsB	964	tetracycline
-e.coli	16S_rrsB	1053	tetracycline
-e.coli	16S_rrsB	1054	tetracycline
-e.coli	16S_rrsB	1055	tetracycline
-e.coli	16S_rrsB	1058	tetracycline
-e.coli	16S_rrsB	1064	spectinomycin
-e.coli	16S_rrsB	1066	spectinomycin
-e.coli	16S_rrsB	1068	spectinomycin
-e.coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
-e.coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
-e.coli	16S_rrsC	794	kasugamicin
-e.coli	16S_rrsC	926	kasugamicin
-e.coli	16S_rrsC	1519	kasugamicin
-e.coli	16S_rrsH	1192	spectinomycin
-e.coli	ampC_promoter_size_53bp	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrB	136	aminocoumarin
+escherichia_coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	56	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	57	None
+escherichia_coli	parC	60	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	78	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	80	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	84	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	108	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	416	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	423	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	439	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	444	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	458	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	460	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	464	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	470	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	475	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	476	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	529	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	pmrA	39	colistin
+escherichia_coli	pmrA	81	colistin
+escherichia_coli	pmrB	161	colistin
+escherichia_coli	folP	64	sulfisoxazole
+escherichia_coli	rpoB	146	rifamycin
+escherichia_coli	rpoB	513	rifamycin
+escherichia_coli	rpoB	526	rifamycin
+escherichia_coli	rpoB	529	rifamycin
+escherichia_coli	rpoB	531	rifamycin
+escherichia_coli	rpoB	533	rifamycin
+escherichia_coli	rpoB	563	rifamycin
+escherichia_coli	rpoB	564	rifamycin
+escherichia_coli	rpoB	687	rifamycin
+escherichia_coli	23S	2059	erythromycin,azithromycin
+escherichia_coli	16S_rrsB	523	streptomycin
+escherichia_coli	16S_rrsB	527	streptomycin
+escherichia_coli	16S_rrsB	528	streptomycin
+escherichia_coli	16S_rrsB	964	tetracycline
+escherichia_coli	16S_rrsB	1053	tetracycline
+escherichia_coli	16S_rrsB	1054	tetracycline
+escherichia_coli	16S_rrsB	1055	tetracycline
+escherichia_coli	16S_rrsB	1058	tetracycline
+escherichia_coli	16S_rrsB	1064	spectinomycin
+escherichia_coli	16S_rrsB	1066	spectinomycin
+escherichia_coli	16S_rrsB	1068	spectinomycin
+escherichia_coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
+escherichia_coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
+escherichia_coli	16S_rrsC	794	kasugamicin
+escherichia_coli	16S_rrsC	926	kasugamicin
+escherichia_coli	16S_rrsC	1519	kasugamicin
+escherichia_coli	16S_rrsH	1192	spectinomycin
+escherichia_coli	ampC_promoter_size_53bp	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter_size_53bp	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter_size_53bp	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter_size_53bp	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 campylobacter	gyrA	70	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	85	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	86	ciprofloxacin,nalidixic acid

--- a/staramr/databases/resistance/data/info.ini
+++ b/staramr/databases/resistance/data/info.ini
@@ -1,3 +1,3 @@
 [Versions]
-pointfinder_gene_drug_version = 072621
+pointfinder_gene_drug_version = 072621.1
 resfinder_gene_drug_version = 072621

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -1100,7 +1100,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.31, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '145/145', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ampC_promoter_size_53bp (C-42T)]',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin,amoxicillin/clavulanic acid,cefoxitin',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ampC_promoter_size_53bp-Cn42T.fsa')
@@ -1177,7 +1177,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.31, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.69, places=2, msg='Wrong overlap')  # Blast reports 100.69
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '146/145', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ampC_promoter_size_53bp (ins-13G)]',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin,amoxicillin/clavulanic acid,cefoxitin',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ampC_promoter_size_53bp-n13insG.fsa')

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -1100,7 +1100,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.31, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '145/145', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin,amoxicillin/clavulanic acid,cefoxitin',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin, amoxicillin/clavulanic acid, cefoxitin',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ampC_promoter_size_53bp-Cn42T.fsa')
@@ -1177,7 +1177,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.31, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.69, places=2, msg='Wrong overlap')  # Blast reports 100.69
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '146/145', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin,amoxicillin/clavulanic acid,cefoxitin',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin, amoxicillin/clavulanic acid, cefoxitin',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ampC_promoter_size_53bp-n13insG.fsa')


### PR DESCRIPTION
Switch name `e.coli` to `escherichia_coli` in PointFinder gene-drug key to match organism name in PointFinder database.