### PR TITLE
Print error even if blast error message does not match pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 0.9.1
 
-* Fixed a bug that occured when parsing some plasmid FASTA record IDs.
+* Fixed a bug that occured when parsing some plasmid FASTA record IDs ([PR 159](https://github.com/phac-nml/staramr/pull/159)).
+* Fixed issue where sometimes the extraction of error messages from `makeblastdb` was crashing leading to less useful errors ([PR 160](https://github.com/phac-nml/staramr/pull/160)).
 
 # Version 0.9.0
 

--- a/staramr/blast/JobHandler.py
+++ b/staramr/blast/JobHandler.py
@@ -286,5 +286,7 @@ class JobHandler:
             subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as e:
             err_msg = str(e.stderr.strip())
-            err_msg = re.findall('REF\|(.*?)\'', err_msg)[0]
+            err_msg_match = re.findall('REF\|(.*?)\'', err_msg)
+            if len(err_msg_match) > 0:
+                err_msg = err_msg_match[0]
             raise Exception('Could not run makeblastdb on file {}, error {}'.format(file, err_msg))


### PR DESCRIPTION
Fix for #155 

# Error message

```
  File "/usr/local/tools/_conda/envs/__staramr@0.7.2/lib/python3.7/site-packages/staramr/blast/JobHandler.py", line 289, in _make_blast_db
    err_msg = re.findall('REF\|(.*?)\'', err_msg)[0]
IndexError: list index out of range
```

# Cause

While we weren't able to reproduce the issue, the error itself is triggered because we are parsing the output of `makeblastdb` and searching for particular patterns to extract an appropriate error message (`re.findall('REF\|(.*?)\''`). Perhaps either STDERR of `makeblastdb` was empty for the above issue, or different versions of blast print different messages. See below code

https://github.com/phac-nml/staramr/blob/6e8ded8a150f01bcd2fa0c6e3b116bf5c567c1dd/staramr/blast/JobHandler.py#L287-L290

# Solution

The fix works by defaulting to just printing the full STDERR of `makeblastdb` if we can't pull out a more specific error message (rather than crashing).