### PR TITLE
Fixed install instructions to not mention specific version of staramr

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,10 +25,8 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            pandas-version: "0.23.0"
             other-packages: "'numpy <1.23.5'"
           - python-version: "3.10"
-            pandas-version: "1.5.2"
             other-packages: ""
 
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,9 +45,8 @@ jobs:
           conda info
           conda list
           conda config --add channels defaults
-          conda config --add channels bioconda
           conda config --add channels conda-forge
-          conda config --set channel_priority strict
+          conda config --add channels bioconda
           conda install mamba
           mamba install Cython blast git mlst ${{ matrix.other-packages }} -y
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            other-packages: "'numpy <1.23.5' 'pandas==1.4.2'"
+            other-packages: "'numpy <1.23.5'"
           - python-version: "3.10"
             other-packages: "'pandas==1.4.2'"
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-          - python-version: "3.11"
+          - python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            other-packages: "'numpy <1.23.5'"
+            other-packages: "'numpy <1.23.5' 'pandas==1.4.2'"
           - python-version: "3.10"
             other-packages: "'pandas==1.4.2'"
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,8 +24,12 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - python-version: "3.7"
+          - python-version: "3.6"
+            pandas-version: "0.23.0"
+            other-packages: "'biopython<1.80'"
           - python-version: "3.10"
+            pandas-version: "1.5.2"
+            other-packages: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +50,7 @@ jobs:
           conda config --add channels bioconda
           conda config --add channels conda-forge
           conda install mamba
-          mamba install blast git mlst -y
+          mamba install blast git mlst  pandas==${{ matrix.pandas-version }} ${{ matrix.other-packages }} -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,11 +24,11 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - python-version: "3.6"
+          - python-version: "3.7"
             pandas-version: "0.23.0"
             other-packages: "GitPython"
-          - python-version: "3.10"
-            pandas-version: "1.4.2"
+          - python-version: "3.11"
+            pandas-version: "1.5.2"
             other-packages: ""
 
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - python-version: "3.7"
             pandas-version: "0.23.0"
-            other-packages: "numpy <1.23.5"
+            other-packages: "'numpy <1.23.5'"
           - python-version: "3.10"
             pandas-version: "1.5.2"
             other-packages: ""

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,8 +43,8 @@ jobs:
           conda info
           conda list
           conda config --add channels defaults
-          conda config --add channels conda-forge
           conda config --add channels bioconda
+          conda config --add channels conda-forge
           conda install mamba
           mamba install blast git mlst -y
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -48,7 +48,7 @@ jobs:
           conda config --add channels bioconda
           conda config --add channels conda-forge
           conda install mamba
-          mamba install blast git mlst 'perl==5.32.1' pandas==${{ matrix.pandas-version }} ${{ matrix.other-packages }} -y
+          mamba install blast git mlst 'perl==5.32.1' ${{ matrix.other-packages }} -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            other-packages: "'numpy <1.23.5'"
+            other-packages: "'numpy <1.23.5' 'pandas==1.4.2'"
           - python-version: "3.10"
-            other-packages: ""
+            other-packages: "'pandas==1.4.2'"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - python-version: "3.6"
+          - python-version: "3.7"
             pandas-version: "0.23.0"
-            other-packages: "'biopython<1.80'"
+            other-packages: "numpy <1.23.5"
           - python-version: "3.10"
             pandas-version: "1.5.2"
             other-packages: ""

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          activate-environment: foo
+          activate-environment: staramr-env
           python-version: ${{ matrix.python-version }}
 
       - name: Install conda packages
@@ -47,6 +47,7 @@ jobs:
           conda config --add channels defaults
           conda config --add channels bioconda
           conda config --add channels conda-forge
+          conda config --set channel_priority strict
           conda install mamba
           mamba install Cython blast git mlst ${{ matrix.other-packages }} -y
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -48,7 +48,7 @@ jobs:
           conda config --add channels bioconda
           conda config --add channels conda-forge
           conda install mamba
-          mamba install blast git mlst 'perl==5.32.1' ${{ matrix.other-packages }} -y
+          mamba install Cython blast git mlst ${{ matrix.other-packages }} -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -48,7 +48,7 @@ jobs:
           conda config --add channels bioconda
           conda config --add channels conda-forge
           conda install mamba
-          mamba install blast git mlst  pandas==${{ matrix.pandas-version }} ${{ matrix.other-packages }} -y
+          mamba install blast git mlst 'perl==5.32.1' pandas==${{ matrix.pandas-version }} ${{ matrix.other-packages }} -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            other-packages: "'numpy <1.23.5' 'pandas==1.4.2'"
+            other-packages: "mlst 'numpy <1.23.5' 'pandas <1.4'"
           - python-version: "3.10"
-            other-packages: "'pandas==1.4.2'"
+            other-packages: "'mlst==2.19.0'"
 
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels bioconda
           conda install mamba
-          mamba install Cython blast git mlst ${{ matrix.other-packages }} -y
+          mamba install Cython blast git ${{ matrix.other-packages }} -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,11 +25,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            pandas-version: "0.23.0"
-            other-packages: "GitPython"
           - python-version: "3.11"
-            pandas-version: "1.5.2"
-            other-packages: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +46,7 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels bioconda
           conda install mamba
-          mamba install blast git mlst pandas==${{ matrix.pandas-version }} ${{ matrix.other-packages }} -y
+          mamba install blast git mlst -y
 
       - name: Setup python packages
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,8 +26,6 @@ jobs:
         include:
           - python-version: "3.7"
             other-packages: "mlst 'numpy <1.23.5' 'pandas <1.4'"
-          - python-version: "3.10"
-            other-packages: "'mlst==2.19.0'"
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Switched to only officially supporting Python 3.7+ due to recent incompatibilities with Python 3.6 and some Python packages (numpy, biopython, and others).
+
 # Version 0.9.1
 
 * Fixed a bug that occured when parsing some plasmid FASTA record IDs ([PR 159](https://github.com/phac-nml/staramr/pull/159)).

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ mamba install -c conda-forge -c bioconda -c defaults staramr
 
 You should now be able to run `staramr --help` and recieve a usage statement.
 
-### Using Python 3.6
+### Using Python 3.7
 
-If you wish to install staramr within a conda environment with Python 3.6, you will have to include `'biopython <1.80'` as biopython >= 1.80 is [not compatible with Python 3.6](https://github.com/biopython/biopython/blob/master/NEWS.rst#18-november-2022-biopython-180).
+If you wish to install staramr within a conda environment with Python 3.7, you will have to include `'numpy <1.23.5'` as numpy >= 1.23.5 is [not compatible with Python 3.7](https://github.com/numpy/numpy/releases/tag/v1.23.5).
 
 ```bash
-mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr python=3.6 'biopython <1.80'
+mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr python=3.7 'numpy <1.23.5'
 ```
 
 ## PyPI/Pip
@@ -237,7 +237,7 @@ staramr db restore-default
 
 ## Dependencies
 
-* Python 3.6+
+* Python 3.7+
 * BLAST+
 * Git
 * MLST

--- a/README.md
+++ b/README.md
@@ -156,31 +156,39 @@ staramr db restore-default
 
 ## Bioconda
 
+
+### Separate conda environment
+
 The easiest way to install `staramr` is through [Bioconda][bioconda] (we recommend using [mamba](https://mamba.readthedocs.io/) as an alternative to `conda`).
-
-```bash
-conda install mamba # Install mamba to make it easier to install later dependencies
-mamba install -c conda-forge -c bioconda -c defaults staramr
-```
-
-This will install the `staramr` Python package at the most recent version. Bioconda will install all necessary dependencies and databases. Once this is complete you can run:
-
-```bash
-staramr --help
-```
-
-If you wish to use `staramr` in an isolated environment (in case dependencies conflict) you may alternatively install with:
 
 ```bash
 conda install mamba # Install mamba to make it easier to install later dependencies
 mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr
 ```
 
-To run `staramr` in this case, you must first activate the environment.  That is:
+This will install the `staramr` software at the most recent version within the conda environment named `staramr`. Bioconda will install all necessary dependencies and databases. Once this is complete you can run:
 
 ```bash
-conda activate staramr
+conda activte staramr # Activate conda environment
 staramr --help
+```
+
+### Same conda environment
+
+If, instead, you wish to install `staramr` to the current conda environment you can run:
+
+```bash
+mamba install -c conda-forge -c bioconda -c defaults staramr
+```
+
+You should now be able to run `staramr --help` and recieve a usage statement.
+
+### Using Python 3.6
+
+If you wish to install staramr within a conda environment with Python 3.6, you will have to include `'biopython <1.80'` as biopython >= 1.80 is [not compatible with Python 3.6](https://github.com/biopython/biopython/blob/master/NEWS.rst#18-november-2022-biopython-180).
+
+```bash
+mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr python=3.6 'biopython <1.80'
 ```
 
 ## PyPI/Pip

--- a/README.md
+++ b/README.md
@@ -183,14 +183,6 @@ mamba install -c conda-forge -c bioconda -c defaults staramr
 
 You should now be able to run `staramr --help` and recieve a usage statement.
 
-### Using Python 3.7
-
-If you wish to install staramr within a conda environment with Python 3.7, you will have to include `'numpy <1.23.5'` as numpy >= 1.23.5 is [not compatible with Python 3.7](https://github.com/numpy/numpy/releases/tag/v1.23.5).
-
-```bash
-mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr python=3.7 'numpy <1.23.5'
-```
-
 ## PyPI/Pip
 
 You can also install `staramr` from [PyPI][pypi-staramr] using `pip`:

--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ The easiest way to install `staramr` is through [Bioconda][bioconda] (we recomme
 
 ```bash
 conda install mamba # Install mamba to make it easier to install later dependencies
-mamba install -c bioconda -c conda-forge -c defaults staramr==0.7.2 pandas==1.1.5 mlst==2.19.0
+mamba install -c conda-forge -c bioconda -c defaults staramr
 ```
 
-This will install the `staramr` Python package at version `0.7.2` (replace with whichever version you wish to install). Bioconda will install all necessary dependencies and databases (use `pandas==1.1.5` and `mlst==2.19.0` to solve issues installing the correct dependency versions). Once this is complete you can run:
+This will install the `staramr` Python package at the most recent version. Bioconda will install all necessary dependencies and databases. Once this is complete you can run:
 
 ```bash
 staramr --help
@@ -173,13 +173,13 @@ If you wish to use `staramr` in an isolated environment (in case dependencies co
 
 ```bash
 conda install mamba # Install mamba to make it easier to install later dependencies
-mamba create -c bioconda -c conda-forge -c defaults --name staramr staramr==0.7.2 pandas==1.1.5 mlst==2.19.0
+mamba create -c conda-forge -c bioconda -c defaults --name staramr staramr
 ```
 
 To run `staramr` in this case, you must first activate the environment.  That is:
 
 ```bash
-source activate staramr
+conda activate staramr
 staramr --help
 ```
 


### PR DESCRIPTION
* Fixes installation instructions for `staramr` to not specify a specific version of staramr (it's no longer needed).
* Changed supported Python to 3.7+ due to incompatibilities with Python 3.6 and newer Python packages (biopython, numpy). It should be still possible to run staramr with Python 3.6, but would require sorting out which Python packages to downgrade.
* Fixes channel order for conda (fix for #162)