### PR TITLE
Fixing Typo in Resistance Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Switched to only officially supporting Python 3.7+ due to recent incompatibilities with Python 3.6 and some Python packages (numpy, biopython, and others).
 * Resfinder CGE-predicted phenotypes are now reported in the summary and detailed summary alongside existing predictions.
+* Corrected a typo in the position for acrB in the PointFinder drug key table.
 
 # Version 0.9.1
 

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -48,7 +48,7 @@ salmonella	parE	521	ciprofloxacin I/R,nalidixic acid
 salmonella	16S_rrsD	1065	spectinomycin
 salmonella	16S_rrsD	1192	spectinomycin
 salmonella	parC	57	None
-salmonella	acrB	171	azithromycin
+salmonella	acrB	717	azithromycin
 escherichia_coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	gyrA	81	ciprofloxacin I/R,nalidixic acid

--- a/staramr/databases/resistance/data/info.ini
+++ b/staramr/databases/resistance/data/info.ini
@@ -1,3 +1,3 @@
 [Versions]
-pointfinder_gene_drug_version = 072621.1
+pointfinder_gene_drug_version = 072621.2
 resfinder_gene_drug_version = 072621


### PR DESCRIPTION
The position should be 717 instead of 171.