### PR TITLE
Updating Plasmidfinder Blast Database "enterobacteriaceae" to "enterobacteriales"

### DIFF
--- a/staramr/blast/plasmidfinder/PlasmidfinderBlastDatabase.py
+++ b/staramr/blast/plasmidfinder/PlasmidfinderBlastDatabase.py
@@ -67,7 +67,7 @@ class PlasmidfinderBlastDatabase(AbstractBlastDatabase):
         A Class Method to get a list of plasmidfinder databases that are currently supported by staramr.
         :return: The list of database_type currently supported by staramr.
         """
-        return ['gram_positive', 'enterobacteriaceae', 'enterobacteriales']
+        return ['gram_positive', 'enterobacteriales', 'enterobacteriales']
 
     @classmethod
     def get_config_table(cls, database_dir: str) -> pd.DataFrame:


### PR DESCRIPTION
Fixes #169 and #177.

There's nothing automatic here though. I don't know if you wanted it automatically build the list from the downloaded database files. Let me know!