### PR TITLE
Changing Sensitive to Susceptible in Outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Adds the ability to handle "complex" pbp5 mutations. When appriopriate many pbp5 point mutations will be reported as a single mutation.
 * Resfinder CGE-predicted phenotypes are now reported in the summary and detailed summary alongside existing predictions.
 * Corrected a typo in the position for acrB in the PointFinder drug key table.
+* Changed the word sensitive to susceptible in outputs.
 
 # Version 0.9.1
 

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -78,7 +78,7 @@ class AMRDetectionSummary:
 
             if self._include_phenotype():
                 negative_resistance_entries = pd.DataFrame(
-                    [[x, 'None', 'Sensitive', '', ''] for x in negative_res_names_set],
+                    [[x, 'None', 'Susceptible', '', ''] for x in negative_res_names_set],
                     columns=negative_columns).set_index('Isolate ID')
             else:
                 negative_resistance_entries = pd.DataFrame([[x, 'None', '', ''] for x in negative_res_names_set],

--- a/staramr/results/AMRDetectionSummaryResistance.py
+++ b/staramr/results/AMRDetectionSummaryResistance.py
@@ -61,7 +61,7 @@ class AMRDetectionSummaryResistance(AMRDetectionSummary):
         return ['Isolate ID', 'Gene', 'Predicted Phenotype', 'Start', 'End']
 
     def _get_summary_empty_values(self):
-        return {'Genotype': 'None', 'Predicted Phenotype': 'Sensitive'}
+        return {'Genotype': 'None', 'Predicted Phenotype': 'Susceptible'}
 
     def _get_summary_resistance_columns(self):
         return ['Genotype', 'Predicted Phenotype', 'CGE Predicted Phenotype', 'Plasmid']

--- a/staramr/subcommand/Search.py
+++ b/staramr/subcommand/Search.py
@@ -124,7 +124,7 @@ class Search(SubCommand):
                                   default=ExcludeGenesList.get_default_exclude_file(),
                                   required=False)
         report_group.add_argument('--exclude-negatives', action='store_true', dest='exclude_negatives',
-                                  help='Exclude negative results (those sensitive to antimicrobials) [False].',
+                                  help='Exclude negative results (those susceptible to antimicrobials) [False].',
                                   required=False)
         report_group.add_argument('--exclude-resistance-phenotypes', action='store_true',
                                   dest='exclude_resistance_phenotypes',

--- a/staramr/tests/integration/detection/test_AMRDetectionPlasmid.py
+++ b/staramr/tests/integration/detection/test_AMRDetectionPlasmid.py
@@ -199,7 +199,7 @@ class AMRDetectionPlasmid(unittest.TestCase):
         self.assertEqual(len(summary_results.index), 1, 'Wrong number of rows')
 
         self.assertEqual(summary_results['Genotype'].iloc[0], 'None', msg='Wrong Genotype value')
-        self.assertEqual(summary_results['Predicted Phenotype'].iloc[0], 'Sensitive',
+        self.assertEqual(summary_results['Predicted Phenotype'].iloc[0], 'Susceptible',
                          msg='Wrong Predicted Phenotype value')
         self.assertEqual(summary_results['Plasmid'].iloc[0], 'IncFII(pKPX1)', msg='Wrong Plasmid Type')
 
@@ -217,7 +217,7 @@ class AMRDetectionPlasmid(unittest.TestCase):
         self.assertEqual(len(summary_results.index), 1, 'Wrong number of rows')
 
         self.assertEqual(summary_results['Genotype'].iloc[0], 'None', msg='Wrong Genotype value')
-        self.assertEqual(summary_results['Predicted Phenotype'].iloc[0], 'Sensitive',
+        self.assertEqual(summary_results['Predicted Phenotype'].iloc[0], 'Susceptible',
                          msg='Wrong Predicted Phenotype value')
         self.assertEqual(summary_results['Plasmid'].iloc[0], 'rep21', msg='Wrong Plasmid Type')
 

--- a/staramr/tests/unit/results/test_AMRDetectionSummary.py
+++ b/staramr/tests/unit/results/test_AMRDetectionSummary.py
@@ -597,7 +597,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('None', detailed_summary['Gene'].iloc[1], 'Genes not equal')
 
         self.assertEqual('', detailed_summary['Predicted Phenotype'].iloc[0], 'Predicted Phenotype not equal')
-        self.assertEqual('Sensitive', detailed_summary['Predicted Phenotype'].iloc[1], 'Predicted Phenotype not equal')
+        self.assertEqual('Susceptible', detailed_summary['Predicted Phenotype'].iloc[1], 'Predicted Phenotype not equal')
 
     def testDetailedSummary_noRes_noPlasmid(self):
         point_table = self.pointfinder_table
@@ -676,7 +676,7 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('None', detailed_summary['Gene'].iloc[1], 'Genes not equal')
 
         self.assertEqual('', detailed_summary['Predicted Phenotype'].iloc[0], 'Predicted Phenotype not equal')
-        self.assertEqual('Sensitive', detailed_summary['Predicted Phenotype'].iloc[1], 'Predicted Phenotype not equal')
+        self.assertEqual('Susceptible', detailed_summary['Predicted Phenotype'].iloc[1], 'Predicted Phenotype not equal')
 
     def testDetailedSummary_multiFiles(self):
         amr_detection_summary = AMRDetectionSummaryResistance(self.detailed_summary_multi_files,
@@ -726,8 +726,8 @@ class AMRDetectionSummaryTest(unittest.TestCase):
         self.assertEqual('IncFIB(K)', detailed_summary['Gene'].iloc[10], 'Genes not equal')
         self.assertEqual('None', detailed_summary['Gene'].iloc[11], 'Genes not equal')
 
-        self.assertEqual('Sensitive', detailed_summary['Predicted Phenotype'].iloc[9], 'Predicted Phenotype not equal')
-        self.assertEqual('Sensitive', detailed_summary['Predicted Phenotype'].iloc[11], 'Predicted Phenotype not equal')
+        self.assertEqual('Susceptible', detailed_summary['Predicted Phenotype'].iloc[9], 'Predicted Phenotype not equal')
+        self.assertEqual('Susceptible', detailed_summary['Predicted Phenotype'].iloc[11], 'Predicted Phenotype not equal')
 
     def testSimplifyingPointfinderMutations(self):
         df = pd.DataFrame([


### PR DESCRIPTION
Address #164.

Also note this change (sensitive to susceptible in the help text), which I thought was appropriate, but may be wrong:

```
        report_group.add_argument('--exclude-negatives', action='store_true', dest='exclude_negatives',
                                  help='Exclude negative results (those susceptible to antimicrobials) [False].',
```