### PR TITLE
Adding CGE Predicted Phenotypes to Pointfinder Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Added CGE-predicted phenotypes to Pointfinder output.
 * The resfinder.tsv and pointfinder.tsv outputs now contain a Notes column.
 * Updated the help description of the --mlst-scheme parameter to include a more useful link for available schemas.
 * Switched to only officially supporting Python 3.7+ due to recent incompatibilities with Python 3.6 and some Python packages (numpy, biopython, and others).

--- a/staramr/blast/pointfinder/PointfinderBlastDatabase.py
+++ b/staramr/blast/pointfinder/PointfinderBlastDatabase.py
@@ -53,7 +53,7 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         """
         return self._pointfinder_info.get_resistance_codons(gene, codon_mutations)
 
-    def get_cge_predicted_phenotype(self, gene, codon_mutation):
+    def get_phenotype(self, gene, codon_mutation):
         """
         Gets the phenotype for a given gene and codon mutation from PointFinder.
         :param gene: The gene.

--- a/staramr/blast/pointfinder/PointfinderBlastDatabase.py
+++ b/staramr/blast/pointfinder/PointfinderBlastDatabase.py
@@ -53,7 +53,7 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         """
         return self._pointfinder_info.get_resistance_codons(gene, codon_mutations)
 
-    def get_phenotype(self, gene, codon_mutation):
+    def get_cge_predicted_phenotype(self, gene, codon_mutation):
         """
         Gets the phenotype for a given gene and codon mutation from PointFinder.
         :param gene: The gene.
@@ -113,6 +113,17 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         """
 
         return self._pointfinder_info.get_notes(gene, mutation)
+
+    def get_cge_phenotype(self, gene, mutation):
+        """
+        Gets the phenotype associated with a particular mutation from the Pointfinder Database table.
+
+        :param gene: The gene.
+        :param mutation: The mutation.
+        :return: A string containtain the phenotype, if it exists.
+        """
+
+        return self._pointfinder_info.cge_predicted_phenotype(gene, mutation)
 
     @classmethod
     def get_available_organisms(cls):

--- a/staramr/blast/pointfinder/PointfinderBlastDatabase.py
+++ b/staramr/blast/pointfinder/PointfinderBlastDatabase.py
@@ -53,15 +53,6 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         """
         return self._pointfinder_info.get_resistance_codons(gene, codon_mutations)
 
-    def get_phenotype(self, gene, codon_mutation):
-        """
-        Gets the phenotype for a given gene and codon mutation from PointFinder.
-        :param gene: The gene.
-        :param codon_mutation: The codon mutation.
-        :return: A string describing the phenotype.
-        """
-        return self._pointfinder_info.get_phenotype(gene, codon_mutation)
-
     def get_resistance_nucleotides(self, gene, nucleotide_mutations):
         """
         Gets a list of resistance nucleotides from the given gene and nucleotide mutations.
@@ -123,7 +114,7 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         :return: A string containtain the phenotype, if it exists.
         """
 
-        return self._pointfinder_info.cge_predicted_phenotype(gene, mutation)
+        return self._pointfinder_info.get_phenotype(gene, mutation)
 
     @classmethod
     def get_available_organisms(cls):

--- a/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
+++ b/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
@@ -221,6 +221,6 @@ class PointfinderDatabaseInfo:
         matches = matches.fillna("")
 
         # There's a chance of having multiple matches:
-        notes = ';'.join(matches["Resistance"])
+        resistances = ';'.join(matches["Resistance"])
 
-        return notes
+        return resistances

--- a/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
+++ b/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
@@ -220,3 +220,21 @@ class PointfinderDatabaseInfo:
         notes = ';'.join(matches["Notes"])
 
         return notes
+
+    def get_cge_predicted_phenotype(self, gene, mutation):
+        """
+        Gets the phenotype associated with a particular mutation from the Pointfinder Database table.
+
+        :param gene: The gene.
+        :param mutation: The mutation.
+        :return: A string containing the phenotype, if it exists, or the empty string ("") if
+                 there is no phenotype.
+        """
+
+        matches = self._get_resistance_codon_match(gene, mutation)
+        matches = matches.fillna("")
+
+        # There's a chance of having multiple matches:
+        notes = ';'.join(matches["Resistance"])
+
+        return notes

--- a/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
+++ b/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
@@ -157,20 +157,6 @@ class PointfinderDatabaseInfo:
     def _get_resistance_nucleotide_match(self, gene, nucleotide_mutations):
         return self._get_resistance_codon_match(gene, nucleotide_mutations)
 
-    def get_phenotype(self, gene, codon_mutation):
-        """
-        Gets the phenotype for a given gene and codon mutation from PointFinder.
-        :param gene: The gene.
-        :param codon_mutation: The codon mutation.
-        :return: A string describing the phenotype.
-        """
-        match = self._get_resistance_codon_match(gene, codon_mutation)
-
-        if len(match.index) > 0:
-            return match['Resistance'].iloc[0]
-        else:
-            raise GenotypePhenotypeMatchException("Error, no match for gene=" + str(gene) + ", codon_mutation=" + str(codon_mutation))
-
     def get_resistance_codons(self, gene, codon_mutations):
         """
         Gets a list of resistance codons from the given gene and codon mutations.
@@ -221,7 +207,7 @@ class PointfinderDatabaseInfo:
 
         return notes
 
-    def get_cge_predicted_phenotype(self, gene, mutation):
+    def get_phenotype(self, gene, mutation):
         """
         Gets the phenotype associated with a particular mutation from the Pointfinder Database table.
 

--- a/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
+++ b/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
@@ -60,7 +60,7 @@ class BlastResultsParserPointfinderResistance(BlastResultsParserPointfinder):
         arg_drug = self._arg_drug_table.get_drug(self._blast_database.get_organism(), hit.get_amr_gene_id(),
                                              mutation_position)
         
-        cge_drug = self._blast_database.get_cge_predicted_phenotype(hit.get_amr_gene_id(), db_mutation)
+        cge_drug = self._blast_database.get_cge_phenotype(hit.get_amr_gene_id(), db_mutation)
 
         gene_name = hit.get_amr_gene_id() + " (" + db_mutation.get_mutation_string_short() + ")"
 

--- a/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
+++ b/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
@@ -16,6 +16,7 @@ class BlastResultsParserPointfinderResistance(BlastResultsParserPointfinder):
     Isolate ID
     Gene
     Predicted Phenotype
+    CGE Predicted Phenotype
     Type
     Position
     Mutation
@@ -56,16 +57,23 @@ class BlastResultsParserPointfinderResistance(BlastResultsParserPointfinder):
         else:
             mutation_position = db_mutation.get_mutation_position()
 
-        drug = self._arg_drug_table.get_drug(self._blast_database.get_organism(), hit.get_amr_gene_id(),
+        arg_drug = self._arg_drug_table.get_drug(self._blast_database.get_organism(), hit.get_amr_gene_id(),
                                              mutation_position)
+        
+        cge_drug = self._blast_database.get_cge_predicted_phenotype(hit.get_amr_gene_id(), db_mutation)
+
         gene_name = hit.get_amr_gene_id() + " (" + db_mutation.get_mutation_string_short() + ")"
 
-        if drug is None:
-            drug = 'unknown[' + gene_name + ']'
+        if arg_drug is None:
+            arg_drug = 'unknown[' + gene_name + ']'
+
+        if cge_drug is None:
+            cge_drug = 'unknown[' + gene_name + ']'
 
         result = [hit.get_genome_id(),
                 gene_name,
-                drug,
+                arg_drug,
+                cge_drug,
                 db_mutation.get_type(),
                 db_mutation.get_mutation_position(),
                 db_mutation.get_mutation_string(),

--- a/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
+++ b/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
@@ -54,7 +54,7 @@ class ComplexMutations:
                 result = [hit.get_genome_id(),
                         ", ".join(intersection), # Technically these are also Pointfinder co-ords
                         row.phenotype,
-                        "N/A", #  CGE-predicted phenotype
+                        "N/A",  # CGE-predicted phenotype
                         "complex",  # Type
                         ", ".join(mutation_positions),
                         "complex", # Creating a mutation string would be confusing for this.

--- a/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
+++ b/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
@@ -54,7 +54,7 @@ class ComplexMutations:
                 result = [hit.get_genome_id(),
                         ", ".join(intersection), # Technically these are also Pointfinder co-ords
                         row.phenotype,
-                        "None",  # CGE-predicted phenotype
+                        None,  # CGE-predicted phenotype
                         "complex",  # Type
                         ", ".join(mutation_positions),
                         "complex", # Creating a mutation string would be confusing for this.

--- a/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
+++ b/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
@@ -54,7 +54,8 @@ class ComplexMutations:
                 result = [hit.get_genome_id(),
                         ", ".join(intersection), # Technically these are also Pointfinder co-ords
                         row.phenotype,
-                        "complex",
+                        "N/A", #  CGE-predicted phenotype
+                        "complex",  # Type
                         ", ".join(mutation_positions),
                         "complex", # Creating a mutation string would be confusing for this.
                         hit.get_pid(),

--- a/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
+++ b/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
@@ -54,7 +54,7 @@ class ComplexMutations:
                 result = [hit.get_genome_id(),
                         ", ".join(intersection), # Technically these are also Pointfinder co-ords
                         row.phenotype,
-                        "N/A",  # CGE-predicted phenotype
+                        "None",  # CGE-predicted phenotype
                         "complex",  # Type
                         ", ".join(mutation_positions),
                         "complex", # Creating a mutation string would be confusing for this.

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -767,7 +767,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin', 'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
         self.assertEqual(result['CGE Notes'].iloc[0],
                          'This mutation represents a combination of multiple individual mutations.',
                          msg='The notes do not match.')  # empty string (no notes)
@@ -860,7 +860,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
 
     def testPointfinderEnterococcusFaecium_pbp5_3_m485t_Success(self):
         # This test evaluates the correctness of identifying a pbp5 complex mutation
@@ -911,7 +911,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
 
     def testResfinderPointfinderSalmonella_16S_C1065T_gyrA_A67_beta_lactam_Success(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -767,7 +767,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin', 'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], None, 'Wrong phenotype')
         self.assertEqual(result['CGE Notes'].iloc[0],
                          'This mutation represents a combination of multiple individual mutations.',
                          msg='The notes do not match.')  # empty string (no notes)
@@ -860,7 +860,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], None, 'Wrong phenotype')
 
     def testPointfinderEnterococcusFaecium_pbp5_3_m485t_Success(self):
         # This test evaluates the correctness of identifying a pbp5 complex mutation
@@ -911,7 +911,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
-        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'None', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], None, 'Wrong phenotype')
 
     def testResfinderPointfinderSalmonella_16S_C1065T_gyrA_A67_beta_lactam_Success(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -464,6 +464,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2637/2637', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin I/R, nalidixic acid',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid,Ciprofloxacin', 'Wrong phenotype')
         self.assertEqual(result['CGE Notes'].iloc[0], '', msg='The notes do not match.')  # empty string (no notes)
 
         hit_file = path.join(self.outdir.name, 'pointfinder_gyrA-A67P.fsa')
@@ -501,6 +502,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2637/2637', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin I/R, nalidixic acid',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid,Ciprofloxacin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_gyrA-S83I.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
@@ -570,6 +572,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2590/2637', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin I/R, nalidixic acid',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid,Ciprofloxacin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_gyrA-A67P-del-end.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
@@ -662,6 +665,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2637/2637', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin I/R, nalidixic acid',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid,Ciprofloxacin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_gyrA-A67P-rc.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
@@ -702,6 +706,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '1544/1544', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'spectinomycin',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Spectinomycin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_16S_rrsD-1T1065.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
@@ -744,14 +749,15 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 98.28, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[pbp5 (A216S)]',
-                         'Wrong phenotype')
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[pbp5 (A216S)]', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Ampicillin', 'Wrong phenotype')
         self.assertEqual(result['CGE Notes'].iloc[0], 
                          'The nineteen pbp5 mutations must be present simultaneously for resistance phenotype',
                          msg='The notes do not match.')
         
         # Test the complex mutation:
         result = pointfinder_results[pointfinder_results['Gene'] == 'pbp5 (A216S), pbp5 (A499T), pbp5 (A68T), pbp5 (D204G), pbp5 (E100Q), pbp5 (E525D), pbp5 (E629V), pbp5 (E85D), pbp5 (G66E), pbp5 (K144Q), pbp5 (L177I), pbp5 (M485A), pbp5 (N496K), pbp5 (P667S), pbp5 (R34Q), pbp5 (S27G), pbp5 (T172A), pbp5 (T324A), pbp5 (V24A), pbp5 (V586L)']
+        print(result.iloc[0].values.tolist())
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'pbp5_20', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'complex', msg='Wrong type')
@@ -760,8 +766,8 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 98.28, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
-                         'Wrong phenotype')
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
         self.assertEqual(result['CGE Notes'].iloc[0],
                          'This mutation represents a combination of multiple individual mutations.',
                          msg='The notes do not match.')  # empty string (no notes)
@@ -799,6 +805,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[pbp5 (A216S)]',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Ampicillin', 'Wrong phenotype')
         
         # Test correct numbers of complex- and codon-type mutations:
         self.assertEqual(len(pointfinder_results[pointfinder_results['Type'] == 'codon']), 19, 'Wrong number of codon mutations')
@@ -839,6 +846,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[pbp5 (E629V)]',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Ampicillin', 'Wrong phenotype')
         
         # Test the complex mutation:
         result = pointfinder_results[pointfinder_results['Gene'] == 'pbp5 (E629V), pbp5 (M485A), pbp5 (P667S)']
@@ -852,6 +860,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
 
     def testPointfinderEnterococcusFaecium_pbp5_3_m485t_Success(self):
         # This test evaluates the correctness of identifying a pbp5 complex mutation
@@ -888,6 +897,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[pbp5 (E629V)]',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Ampicillin', 'Wrong phenotype')
         
         # Test the complex mutation:
         result = pointfinder_results[pointfinder_results['Gene'] == 'pbp5 (E629V), pbp5 (M485T), pbp5 (P667S)']
@@ -901,6 +911,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'N/A', 'Wrong phenotype')
 
     def testResfinderPointfinderSalmonella_16S_C1065T_gyrA_A67_beta_lactam_Success(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -950,6 +961,8 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '1544/1544', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'spectinomycin',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Spectinomycin',
+                         'Wrong phenotype')
 
         result = pointfinder_results[pointfinder_results['Gene'] == 'gyrA (A67P)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
@@ -961,6 +974,8 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2637/2637', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin I/R, nalidixic acid',
+                         'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid,Ciprofloxacin',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_16S_gyrA_beta-lactam.fsa')
@@ -1045,6 +1060,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '1544/1544', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'spectinomycin',
                          'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Spectinomycin', 'Wrong phenotype')
 
         result = pointfinder_results[pointfinder_results['Gene'] == 'gyrA (A67P)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
@@ -1162,6 +1178,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2592/2592', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ciprofloxacin, nalidixic acid', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Nalidixic acid, Ciprofloxacin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_gyrA-A70T.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
@@ -1198,6 +1215,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2912/2912', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0],
                          'erythromycin, azithromycin, telithromycin, clindamycin', 'Wrong phenotype')
+        self.assertEqual(result['CGE Predicted Phenotype'].iloc[0], 'Azithromycin, Erythromycin, Clindamycin, Telithromycin', 'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_23S-A2075G.fsa')
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))

--- a/staramr/tests/unit/blast/pointfinder/test_PointfinderDatabaseInfo.py
+++ b/staramr/tests/unit/blast/pointfinder/test_PointfinderDatabaseInfo.py
@@ -98,9 +98,6 @@ class PointfinderDatabaseInfoTest(unittest.TestCase):
 
         self.assertEqual(phenotype, 'Quinolones')
 
-    def testGetResfinderPhenotypeMissingFail(self):
-        self.assertRaises(Exception, self.database.get_phenotype, 'gyrA', self.mutation_missing)
-
     def test_get_notes(self):
 
         # Mutation 1


### PR DESCRIPTION
#170 

I realized when doing testing that there was an existing function that already did some of this functionality. I cleaned up the duplicate functions, but one particular difference is that the old (unused) `get_phenotype` function raised an exception when there was no phenotype found for a particular mutation. I removed this exception because I believe our primary source of phenotypes for Pointfinder is the ARG database. However, if you believe it should exist, I can re-add it.