### PR TITLE
Changing CGE Notes Entry for Complex Mutations

### DIFF
--- a/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
+++ b/staramr/databases/resistance/pointfinder/complex/ComplexMutations.py
@@ -65,7 +65,7 @@ class ComplexMutations:
                         hit.get_genome_contig_start(),
                         hit.get_genome_contig_end(),
                         ", ".join(intersection),
-                        "This mutation represents a combination of multiple individual mutations.", # The notes.
+                        pd.NA, # The CGE notes.
                         pd.NA,
                         pd.NA,
                         pd.NA]

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -786,9 +786,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin', 'Wrong phenotype')
         self.assertTrue(pd.isna(result['CGE Predicted Phenotype'].iloc[0]), 'Wrong phenotype')
-        self.assertEqual(result['CGE Notes'].iloc[0],
-                         'This mutation represents a combination of multiple individual mutations.',
-                         msg='The notes do not match.')  # empty string (no notes)
+        self.assertTrue(pd.isna(result['CGE Notes']), msg='The notes do not match.')
         self.assertTrue(pd.isna(result['CGE PMID'].iloc[0]), msg='The PMIDs do not match.')
         self.assertTrue(pd.isna(result['CGE Mechanism'].iloc[0]), msg='The mechanisms do not match.')
         self.assertTrue(pd.isna(result['CGE Required Mutation'].iloc[0]), msg='The required mutation(s) do not match.')

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -786,7 +786,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '2037/2037', msg='Wrong lengths')
         self.assertEqual(result['Predicted Phenotype'].iloc[0], 'ampicillin', 'Wrong phenotype')
         self.assertTrue(pd.isna(result['CGE Predicted Phenotype'].iloc[0]), 'Wrong phenotype')
-        self.assertTrue(pd.isna(result['CGE Notes']), msg='The notes do not match.')
+        self.assertTrue(pd.isna(result['CGE Notes'].iloc[0]), msg='The notes do not match.')
         self.assertTrue(pd.isna(result['CGE PMID'].iloc[0]), msg='The PMIDs do not match.')
         self.assertTrue(pd.isna(result['CGE Mechanism'].iloc[0]), msg='The mechanisms do not match.')
         self.assertTrue(pd.isna(result['CGE Required Mutation'].iloc[0]), msg='The required mutation(s) do not match.')


### PR DESCRIPTION
The CGE Notes column for all complex mutations used to say "This mutation represents a combination of multiple individual mutations." This is true, but "CGE Notes" should really only contain text taken from CGE, not all notes. This is a hold-over from when the column was just called "Notes".

I've changed it so complex mutations have nothing under the "CGE Notes" column.