### PR TITLE
Update Resfinder and Pointfinder Databases

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DATABASE_COMMITS: '--resfinder-commit d1e607b8989260c7b6a3fbce8fa3204ecfc09022 --pointfinder-commit 8c694b9f336153e6d618b897b3b4930961521eb8 --plasmidfinder-commit c18e08c17a5988d4f075fc1171636e47546a323d'
+      DATABASE_COMMITS: '--resfinder-commit d1e607b8989260c7b6a3fbce8fa3204ecfc09022 --pointfinder-commit 694919f59a38980204009e7ade76bf319cb7df0b --plasmidfinder-commit c18e08c17a5988d4f075fc1171636e47546a323d'
     
     strategy:
       fail-fast: False

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -61,4 +61,6 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: pytest
+        run: |
+          pip install pytest
+          pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: python setup.py test
+        run: pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DATABASE_COMMITS: '--resfinder-commit fa32d9a3cf0c12ec70ca4e90c45c0d590ee810bd --pointfinder-commit 8c694b9f336153e6d618b897b3b4930961521eb8 --plasmidfinder-commit c18e08c17a5988d4f075fc1171636e47546a323d'
+      DATABASE_COMMITS: '--resfinder-commit d1e607b8989260c7b6a3fbce8fa3204ecfc09022 --pointfinder-commit 8c694b9f336153e6d618b897b3b4930961521eb8 --plasmidfinder-commit c18e08c17a5988d4f075fc1171636e47546a323d'
     
     strategy:
       fail-fast: False

--- a/staramr/blast/plasmidfinder/PlasmidfinderBlastDatabase.py
+++ b/staramr/blast/plasmidfinder/PlasmidfinderBlastDatabase.py
@@ -75,8 +75,8 @@ class PlasmidfinderBlastDatabase(AbstractBlastDatabase):
         A Class Method to get the config table from the plasmidfinder database root directory.
         :return: A DataFrame containing the config table.
         """
-        config = pd.read_csv(path.join(database_dir, 'config'), sep='\t', comment='#', header=None,
-                             names=['db_prefix', 'name', 'description'])
+        config = pd.read_csv(path.join(database_dir, 'config'), sep=r'\t|\s{4,}', comment='#', header=None,
+                             names=['db_prefix', 'name', 'description'], engine='python')
         return config
 
     @classmethod

--- a/staramr/blast/pointfinder/PointfinderBlastDatabase.py
+++ b/staramr/blast/pointfinder/PointfinderBlastDatabase.py
@@ -167,8 +167,8 @@ class PointfinderBlastDatabase(AbstractBlastDatabase):
         :param database_dir: The PointFinder database root directory.
         :return: A list of organisms.
         """
-        config = pd.read_csv(path.join(database_dir, 'config'), sep='\t', comment='#', header=None,
-                             names=['db_prefix', 'name', 'description'])
+        config = pd.read_csv(path.join(database_dir, 'config'), sep=r'\t|\s{4,}', comment='#', header=None,
+                             names=['db_prefix', 'name', 'description'], engine='python')
         return config['db_prefix'].tolist()
 
     @classmethod

--- a/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
+++ b/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
@@ -41,7 +41,7 @@ class PointfinderDatabaseInfo:
         line = line.lstrip("#")
         column_names = line.split()
 
-        pointfinder_info = pd.read_csv(file, sep='\t', index_col=False, comment='#', header=None, names=column_names)
+        pointfinder_info = pd.read_csv(file, sep=r'\t|\s{4,}', index_col=False, comment='#', header=None, names=column_names, engine='python')
 
         return cls(pointfinder_info, file)
 

--- a/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
+++ b/staramr/blast/pointfinder/PointfinderDatabaseInfo.py
@@ -107,6 +107,14 @@ class PointfinderDatabaseInfo:
         & (table['Gene_ID'].str.contains('16S') == False)
         & (table['Gene_ID'].str.contains('23S') == False), "Res_codon"].str.replace('[A-Z,]+', self.to_codons, regex=True)
 
+        # We need to correct for the mismatch between promter's FASTA record ID
+        # and the associated gene ID in the resistens-overview.txt file. For example:
+        # FASTA Record ID: >ampC-promoter_1_CP037449.1
+        # Gene ID: ampC_promoter_size_53bp
+        # The gene ID seems to be derived from the file name (ampC-promoter-size-53bp.fsa),
+        # although that still contains mismatching hyphens and underscores.
+        table[['Gene_ID']] = table[['Gene_ID']].replace({r'(.+promoter).+' : r'\1'}, regex=True)
+
     def _get_resistance_codon_match(self, gene, codon_mutation):
         table = self._pointfinder_info
 

--- a/staramr/blast/results/BlastResultsParser.py
+++ b/staramr/blast/results/BlastResultsParser.py
@@ -107,7 +107,7 @@ class BlastResultsParser:
         for hits_non_overlapping in partitions.get_hits_nonoverlapping_regions():
             for hit in self._select_hits_to_include(hits_non_overlapping):
                 blast_results = self._get_result_rows(hit, database_name)
-                if blast_results is not None:
+                if blast_results is not None and database_name != "all":
                     logger.debug("record = %s", blast_results)
                     results.extend(blast_results)
                     hit_seq_records.append(hit.get_seq_record())

--- a/staramr/blast/results/BlastResultsParser.py
+++ b/staramr/blast/results/BlastResultsParser.py
@@ -91,6 +91,13 @@ class BlastResultsParser:
         pass
 
     def _handle_blast_hit(self, in_file, database_name, blast_file, results, hit_seq_records):
+        ignore_database = ["all", "campylobacter",
+        "enterococcus_faecalis", "enterococcus_faecium",
+        "escherichia_coli", "helicobacter_pylori", "klebsiella",
+        "mycobacterium_tuberculosis", "neisseria_gonorrhoeae",
+        "plasmodium_falciparum", "salmonella",
+        "staphylococcus_aureus"]
+
         blast_table = pd.read_csv(blast_file, sep='\t', header=None, names=JobHandler.BLAST_COLUMNS,
                                   index_col=False).astype(
             dtype={'qseqid': np.str_, 'sseqid': np.str_})
@@ -107,7 +114,7 @@ class BlastResultsParser:
         for hits_non_overlapping in partitions.get_hits_nonoverlapping_regions():
             for hit in self._select_hits_to_include(hits_non_overlapping):
                 blast_results = self._get_result_rows(hit, database_name)
-                if blast_results is not None and database_name != "all":
+                if blast_results is not None and database_name not in ignore_database:
                     logger.debug("record = %s", blast_results)
                     results.extend(blast_results)
                     hit_seq_records.append(hit.get_seq_record())

--- a/staramr/blast/results/BlastResultsParser.py
+++ b/staramr/blast/results/BlastResultsParser.py
@@ -93,7 +93,7 @@ class BlastResultsParser:
     def _handle_blast_hit(self, in_file, database_name, blast_file, results, hit_seq_records):
         blast_table = pd.read_csv(blast_file, sep='\t', header=None, names=JobHandler.BLAST_COLUMNS,
                                   index_col=False).astype(
-            dtype={'qseqid': np.unicode_, 'sseqid': np.unicode_})
+            dtype={'qseqid': np.str_, 'sseqid': np.str_})
         partitions = BlastHitPartitions()
 
         blast_table['plength'] = (blast_table.length / blast_table.qlen) * 100.0

--- a/staramr/blast/results/pointfinder/BlastResultsParserPointfinder.py
+++ b/staramr/blast/results/pointfinder/BlastResultsParserPointfinder.py
@@ -48,7 +48,8 @@ class BlastResultsParserPointfinder(BlastResultsParser):
 
     def _create_hit(self, file, database_name, blast_record):
         logger.debug("database_name=%s", database_name)
-        if (database_name == '16S_rrsD') or (database_name == '23S'):
+        if (database_name.startswith('16S_rrs') or database_name.startswith('16S-rrs') \
+            or (database_name == '23S')):
             return PointfinderHitHSPRNA(file, blast_record)
         elif ('promoter' in database_name):
             return PointfinderHitHSPPromoter(file, blast_record, database_name)            

--- a/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
+++ b/staramr/blast/results/pointfinder/BlastResultsParserPointfinderResistance.py
@@ -60,12 +60,12 @@ class BlastResultsParserPointfinderResistance(BlastResultsParserPointfinder):
         else:
             mutation_position = db_mutation.get_mutation_position()
 
-        arg_drug = self._arg_drug_table.get_drug(self._blast_database.get_organism(), hit.get_amr_gene_id(),
+        arg_drug = self._arg_drug_table.get_drug(self._blast_database.get_organism(), hit.get_amr_gene_name(),
                                              mutation_position)
         
-        cge_drug = self._blast_database.get_cge_phenotype(hit.get_amr_gene_id(), db_mutation)
+        cge_drug = self._blast_database.get_cge_phenotype(hit.get_amr_gene_name(), db_mutation)
 
-        gene_name = hit.get_amr_gene_id() + " (" + db_mutation.get_mutation_string_short() + ")"
+        gene_name = hit.get_amr_gene_name() + " (" + db_mutation.get_mutation_string_short() + ")"
 
         if arg_drug is None:
             arg_drug = 'unknown[' + gene_name + ']'
@@ -87,10 +87,10 @@ class BlastResultsParserPointfinderResistance(BlastResultsParserPointfinder):
                 hit.get_genome_contig_start(),
                 hit.get_genome_contig_end(),
                 db_mutation.get_pointfinder_mutation_string(),
-                self._blast_database.get_cge_notes(hit.get_amr_gene_id(), db_mutation),
-                self._blast_database.get_cge_required_mutation(hit.get_amr_gene_id(), db_mutation),
-                self._blast_database.get_cge_mechanism(hit.get_amr_gene_id(), db_mutation),
-                self._blast_database.get_cge_pmid(hit.get_amr_gene_id(), db_mutation),
+                self._blast_database.get_cge_notes(hit.get_amr_gene_name(), db_mutation),
+                self._blast_database.get_cge_required_mutation(hit.get_amr_gene_name(), db_mutation),
+                self._blast_database.get_cge_mechanism(hit.get_amr_gene_name(), db_mutation),
+                self._blast_database.get_cge_pmid(hit.get_amr_gene_name(), db_mutation),
                 ]
 
         return result

--- a/staramr/blast/results/pointfinder/PointfinderHitHSP.py
+++ b/staramr/blast/results/pointfinder/PointfinderHitHSP.py
@@ -28,7 +28,17 @@ class PointfinderHitHSP(AMRHitHSP):
         Gets the particular gene name for the PointFinder hit.
         :return: The gene name.
         """
-        return self._blast_record['qseqid']
+
+        # As far back as 2020, CGE has been editing the FASTA file
+        # record headings used by Pointfinder to include accession
+        # numbers (pmrA -> pmrA_1_CP055130.1). This seems to be part
+        # of a larger initiative by CGE to move from the
+        # resistens-overview.txt file to a new phenotypes.txt file.
+        # However, we need to use the new FASTA record headers with
+        # the legacy resistens-overview.txt names, which unfortunately
+        # requires modifying the gene names back
+        # (pmrA_1_CP055130.1 -> pmrA).
+        return self._blast_record['qseqid'].split("_")[0]
 
     def _get_mutation_positions(self, start):
         mutation_positions = []

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPPromoter.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPPromoter.py
@@ -1,6 +1,7 @@
 from staramr.blast.results.pointfinder.PointfinderHitHSP import PointfinderHitHSP
 from staramr.blast.results.pointfinder.codon.CodonMutationPosition import CodonMutationPosition
 from staramr.blast.results.pointfinder.nucleotide.NucleotideMutationPosition import NucleotideMutationPosition
+import re
 
 
 class PointfinderHitHSPPromoter(PointfinderHitHSP):
@@ -118,3 +119,20 @@ class PointfinderHitHSPPromoter(PointfinderHitHSP):
         size = int(size_string.replace('bp', ''))  # remove the 'bp' and convert to an int
 
         self.offset = size
+
+    def get_amr_gene_name(self):
+        """
+        Gets the particular gene name for the PointfinderHitHSPPromoter hit.
+        :return: The gene name.
+        """
+        name = self._blast_record['qseqid']
+
+        # CGE has been changing FASTA record headers to include accession
+        # numbers, which need to be removed. See PointfinderHitHSP.get_amr_gene_name()
+        # for more information. Furthermore, promoters seem to use the form
+        # "ampC-promoter", whereas the resistens-overview.txt file expects the form
+        # "ampC_promoter_size_53bp".
+        # Ex: ampC-promoter_1_CP037449.1 -> ampC_promoter
+        name = re.sub(r'(.+promoter).+', r'\1', name) # Grab everything up to and include "promoter"
+        name = name.replace('-', "_")
+        return name

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPPromoter.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPPromoter.py
@@ -106,14 +106,14 @@ class PointfinderHitHSPPromoter(PointfinderHitHSP):
         Parses the name of the database in order to obtain the promoter offset.
         The database name is expected to have the following format:
 
-        [GENENAME]_promoter_size_[SIZE]bp
+        [GENENAME]-promoter-size-[SIZE]bp
 
         example:
 
-        embA_promoter_size_115bp
+        embA-promoter-size-115bp
         """
 
-        tokens = database_name.split("_")  # split the name into tokens
+        tokens = database_name.split("-")  # split the name into tokens
         size_string = tokens[len(tokens) - 1]  # get the last token
         size = int(size_string.replace('bp', ''))  # remove the 'bp' and convert to an int
 

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
@@ -24,7 +24,7 @@ class PointfinderHitHSPRNA(PointfinderHitHSP):
         # for more information. Naming schemes are also inconsistent:
         # pointfinder/campylobacter/23S.fsa -> 23S_1_LR134511.1
         # pointfinder/neisseria_gonorrhoeae/23S-rRNA-a1.fsa -> 23S-rRNA-a1_1_AE004969.1
-        if name.startswith("16S_rrsD"): name = "16S_rrsD"
+        if name.startswith("16S_rrs"): name = name.split("_")[0] + "_" + name.split("_")[1]
         elif name.startswith("16S"): name = "16S"
         elif name.startswith("23S"): name = "23S"
         else: name = name.split("_")[0]

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
@@ -12,6 +12,16 @@ class PointfinderHitHSPRNA(PointfinderHitHSP):
         """
         super().__init__(file, blast_record)
 
+    def get_amr_gene_name(self):
+        """
+        Gets the particular gene name for the PointfinderHitHSPRNA hit.
+        :return: The gene name.
+        """
+
+        # This is explicitly overriding the parent class's function
+        # because we want to return this gene name without modification.
+        return self._blast_record['qseqid']
+
     def _get_mutation_positions(self, start):
         mutation_positions = []
 

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
@@ -25,7 +25,7 @@ class PointfinderHitHSPRNA(PointfinderHitHSP):
         # pointfinder/campylobacter/23S.fsa -> 23S_1_LR134511.1
         # pointfinder/neisseria_gonorrhoeae/23S-rRNA-a1.fsa -> 23S-rRNA-a1_1_AE004969.1
         if name.startswith("16S_rrs"): name = name.split("_")[0] + "_" + name.split("_")[1]
-        elif name.startswith("16S"): name = "16S"
+        elif name.startswith("16S-rrs"): name = name.split("_")[0].replace("-", "_", 1) # Ex: 16S-rrsD_1_CP049983.1
         elif name.startswith("23S"): name = "23S"
         else: name = name.split("_")[0]
 

--- a/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
+++ b/staramr/blast/results/pointfinder/nucleotide/PointfinderHitHSPRNA.py
@@ -17,10 +17,19 @@ class PointfinderHitHSPRNA(PointfinderHitHSP):
         Gets the particular gene name for the PointfinderHitHSPRNA hit.
         :return: The gene name.
         """
+        name = self._blast_record['qseqid']
 
-        # This is explicitly overriding the parent class's function
-        # because we want to return this gene name without modification.
-        return self._blast_record['qseqid']
+        # CGE has been changing FASTA record headers to include accession
+        # numbers, which need to be removed. See PointfinderHitHSP.get_amr_gene_name()
+        # for more information. Naming schemes are also inconsistent:
+        # pointfinder/campylobacter/23S.fsa -> 23S_1_LR134511.1
+        # pointfinder/neisseria_gonorrhoeae/23S-rRNA-a1.fsa -> 23S-rRNA-a1_1_AE004969.1
+        if name.startswith("16S_rrsD"): name = "16S_rrsD"
+        elif name.startswith("16S"): name = "16S"
+        elif name.startswith("23S"): name = "23S"
+        else: name = name.split("_")[0]
+
+        return name
 
     def _get_mutation_positions(self, start):
         mutation_positions = []

--- a/staramr/databases/AMRDatabasesManager.py
+++ b/staramr/databases/AMRDatabasesManager.py
@@ -14,7 +14,7 @@ class AMRDatabasesManager:
     # Update to commits corresponding to dates listed on <https://cge.cbs.dtu.dk/services/ResFinder/> (and PlasmidFinder)
     # As of May 26, 2022
     DEFAULT_COMMITS = {
-        'resfinder': 'fa32d9a3cf0c12ec70ca4e90c45c0d590ee810bd', # 2022-05-24
+        'resfinder': 'd1e607b8989260c7b6a3fbce8fa3204ecfc09022', # 2024-08-08
         'pointfinder': '8c694b9f336153e6d618b897b3b4930961521eb8', # 2021-02-01
         'plasmidfinder': 'c18e08c17a5988d4f075fc1171636e47546a323d', # 2023-01-18
     }

--- a/staramr/databases/AMRDatabasesManager.py
+++ b/staramr/databases/AMRDatabasesManager.py
@@ -14,8 +14,8 @@ class AMRDatabasesManager:
     # Update to commits corresponding to dates listed on <https://cge.cbs.dtu.dk/services/ResFinder/> (and PlasmidFinder)
     # As of May 26, 2022
     DEFAULT_COMMITS = {
-        'resfinder': 'd1e607b8989260c7b6a3fbce8fa3204ecfc09022', # 2024-08-08
-        'pointfinder': '8c694b9f336153e6d618b897b3b4930961521eb8', # 2021-02-01
+        'resfinder': 'd1e607b8989260c7b6a3fbce8fa3204ecfc09022', # 2024-08-06
+        'pointfinder': '694919f59a38980204009e7ade76bf319cb7df0b', # 2024-08-08
         'plasmidfinder': 'c18e08c17a5988d4f075fc1171636e47546a323d', # 2023-01-18
     }
 

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -110,10 +110,10 @@ escherichia_coli	16S_rrsC	794	kasugamicin
 escherichia_coli	16S_rrsC	926	kasugamicin
 escherichia_coli	16S_rrsC	1519	kasugamicin
 escherichia_coli	16S_rrsH	1192	spectinomycin
-escherichia_coli	ampC_promoter_size_53bp	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter_size_53bp	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter_size_53bp	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter_size_53bp	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 campylobacter	gyrA	70	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	85	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	86	ciprofloxacin,nalidixic acid

--- a/staramr/subcommand/Search.py
+++ b/staramr/subcommand/Search.py
@@ -194,13 +194,13 @@ class Search(SubCommand):
         for name in ['Summary', 'Detailed_Summary', 'ResFinder', 'PointFinder', 'PlasmidFinder', 'MLST_Summary']:
             if name in sheetname_dataframe:
                 if name == 'Summary':
-                    sheetname_dataframe[name].to_excel(writer, name, freeze_panes=[1, 2], float_format="%0.2f",na_rep=self.BLANK)
+                    sheetname_dataframe[name].to_excel(writer, sheet_name=name, freeze_panes=[1, 2], float_format="%0.2f",na_rep=self.BLANK)
                 else:
-                    sheetname_dataframe[name].to_excel(writer, name, freeze_panes=[1, 1], float_format="%0.2f",na_rep=self.BLANK)
+                    sheetname_dataframe[name].to_excel(writer, sheet_name=name, freeze_panes=[1, 1], float_format="%0.2f",na_rep=self.BLANK)
                 
         self._resize_columns(sheetname_dataframe, writer, max_width=50)
 
-        settings_dataframe.to_excel(writer, 'Settings')
+        settings_dataframe.to_excel(writer, sheet_name='Settings')
         self._resize_columns({'Settings': settings_dataframe}, writer, max_width=75, text_wrap=False)
 
         writer.close()

--- a/staramr/tests/integration/databases/test_AMRDatabasesManager.py
+++ b/staramr/tests/integration/databases/test_AMRDatabasesManager.py
@@ -7,7 +7,7 @@ from staramr.databases.AMRDatabasesManager import AMRDatabasesManager
 
 
 class AMRDatabasesManagerIT(unittest.TestCase):
-    RESFINDER_DEFAULT_COMMIT = 'fa32d9a3cf0c12ec70ca4e90c45c0d590ee810bd'
+    RESFINDER_DEFAULT_COMMIT = 'd1e607b8989260c7b6a3fbce8fa3204ecfc09022'
     POINTFINDER_DEFAULT_COMMIT = '8c694b9f336153e6d618b897b3b4930961521eb8'
     PLASMIDFINDER_DEFAULT_COMMIT = 'c18e08c17a5988d4f075fc1171636e47546a323d'
 

--- a/staramr/tests/integration/databases/test_AMRDatabasesManager.py
+++ b/staramr/tests/integration/databases/test_AMRDatabasesManager.py
@@ -8,7 +8,7 @@ from staramr.databases.AMRDatabasesManager import AMRDatabasesManager
 
 class AMRDatabasesManagerIT(unittest.TestCase):
     RESFINDER_DEFAULT_COMMIT = 'd1e607b8989260c7b6a3fbce8fa3204ecfc09022'
-    POINTFINDER_DEFAULT_COMMIT = '8c694b9f336153e6d618b897b3b4930961521eb8'
+    POINTFINDER_DEFAULT_COMMIT = '694919f59a38980204009e7ade76bf319cb7df0b'
     PLASMIDFINDER_DEFAULT_COMMIT = 'c18e08c17a5988d4f075fc1171636e47546a323d'
 
     def setUp(self):

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -1431,7 +1431,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'ahpC_promoter_size_180bp (F10I)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'ahpC_promoter (F10I)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'ahpC_promoter_size_180bp-F10I', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'codon', msg='Wrong type')
@@ -1440,7 +1440,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.87, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '768/768', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ahpC_promoter_size_180bp (F10I)]',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ahpC_promoter (F10I)]',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ahpC_promoter_size_180bp-F10I.fsa')
@@ -1449,7 +1449,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['ahpC_promoter_size_180bp'].seq.upper(), records['ahpC_promoter_size_180bp'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['ahpC_promoter_size_180bp'].seq.upper(), records['ahpC-promoter_1_CP049108.1'].seq.upper(), "records don't match")
 
     def testPointfinderEscherichiaColin13insGSuccess(self):
         # Insert a G at -13 in the promoter.
@@ -1471,7 +1471,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter_size_53bp (ins-13G)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter (ins-13G)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'ampC_promoter_size_53bp-n13insG', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'nucleotide', msg='Wrong type')
@@ -1489,7 +1489,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC_promoter_size_53bp'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC-promoter_1_CP037449.1'].seq.upper(), "records don't match")
 
     def testPointfinderEscherichiaColin16insGTSuccess(self):
         # Insert a GT at -16 in the promoter.
@@ -1511,7 +1511,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter_size_53bp (ins-16GT)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter (ins-16GT)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'ampC_promoter_size_53bp-n16insGT', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'nucleotide', msg='Wrong type')
@@ -1520,7 +1520,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 98.639, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 101.38, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '147/145', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ampC_promoter_size_53bp (ins-16GT)]',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[ampC_promoter (ins-16GT)]',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_ampC_promoter_size_53bp-n16insGT.fsa')
@@ -1529,7 +1529,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC_promoter_size_53bp'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC-promoter_1_CP037449.1'].seq.upper(), "records don't match")
 
     def testPointfinderNeisseriaGonorrhoeaen57delSuccess(self):
         # Delete the A nucleotide at -57 in the promoter.
@@ -1551,7 +1551,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'mtrR_promoter_size_66bp (del-57A)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'mtrR_promoter (del-57A)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'mtrR_promoter_size_66bp-n57del', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'nucleotide', msg='Wrong type')
@@ -1560,7 +1560,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertAlmostEqual(result['%Identity'].iloc[0], 99.86, places=2, msg='Wrong pid')
         self.assertAlmostEqual(result['%Overlap'].iloc[0], 100.0, places=2, msg='Wrong overlap')
         self.assertEqual(result['HSP Length/Total Length'].iloc[0], '699/699', msg='Wrong lengths')
-        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[mtrR_promoter_size_66bp (del-57A)]',
+        self.assertEqual(result['Predicted Phenotype'].iloc[0], 'unknown[mtrR_promoter (del-57A)]',
                          'Wrong phenotype')
 
         hit_file = path.join(self.outdir.name, 'pointfinder_mtrR_promoter_size_66bp-n57del.fsa')
@@ -1569,7 +1569,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['mtrR_promoter_size_66bp'].seq.upper(), records['mtrR_promoter_size_66bp'].seq.upper().replace('-', ''), "records don't match")
+        self.assertEqual(expected_records['mtrR_promoter_size_66bp'].seq.upper(), records['mtrR-promoter_1_CP012026.1'].seq.upper().replace('-', ''), "records don't match")
 
     def testPointfinderNeisseriaGonorrhoeae78delSuccess(self):
         # Delete the GTT/V nucleotides/codon at pos 78 (nucleotide coords) / pos 27 (codon coords)

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -1226,7 +1226,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_LR134511.1'].seq.upper(), "records don't match")
 
     def testPointfinderCampylobacterA2075GSuccess(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'campylobacter')
@@ -1266,7 +1266,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['23S'].seq.upper(), records['23S'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['23S'].seq.upper(), records['23S_1_LR134511.1'].seq.upper(), "records don't match")
 
     """
     def testPointfinderEFaecalisS97NSuccess(self):
@@ -1652,7 +1652,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['pbp5'].seq.upper(), records['pbp5'].seq.upper().replace('-', ''), "records don't match")
+        self.assertEqual(expected_records['pbp5'].seq.upper(), records['pbp5_1_AAK43724.1'].seq.upper().replace('-', ''), "records don't match")
 
     def testResfinderCGEPredictedPhenotypes(self):
         file = path.join(self.test_data_dir, "beta-lactam-blaIMP-42-ins-start.fsa")
@@ -1711,7 +1711,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA_1_CP073768.1'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA_1_CP073768.1'].seq.upper(), records['gyrA_1_CP073768.1'].seq.upper(), "records don't match")
 
 
 

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -532,7 +532,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'gyrA (A67P)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'gyrA_1_MH933946.1 (A67P)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'gyrA-A67P', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'codon', msg='Wrong type')
@@ -549,7 +549,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
 
     def testPointfinderSalmonellaA67PDelEndSuccess(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -729,7 +729,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['16S_rrsD'].seq.upper(), records['16S_rrsD'].seq.upper(),
+        self.assertEqual(expected_records['16S_rrsD'].seq.upper(), records['16S-rrsD_1_CP049983.1'].seq.upper(),
                          "records don't match")
 
 
@@ -1016,9 +1016,9 @@ class AMRDetectionIT(unittest.TestCase):
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
         self.assertEqual(len(records), 2, 'Wrong number of hit records')
         expected_records1 = SeqIO.to_dict(SeqIO.parse(path.join(self.test_data_dir, 'gyrA-A67P.fsa'), 'fasta'))
-        self.assertEqual(expected_records1['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records1['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
         expected_records2 = SeqIO.to_dict(SeqIO.parse(path.join(self.test_data_dir, '16S_rrsD-1T1065.fsa'), 'fasta'))
-        self.assertEqual(expected_records2['16S_rrsD'].seq.upper(), records['16S_rrsD'].seq.upper(),
+        self.assertEqual(expected_records2['16S_rrsD'].seq.upper(), records['16S-rrsD_1_CP049983.1'].seq.upper(),
                          "records don't match")
 
     def testResfinderPointfinderSalmonellaExcludeGenesListSuccess(self):
@@ -1028,7 +1028,7 @@ class AMRDetectionIT(unittest.TestCase):
         amr_detection = AMRDetectionResistance(self.resfinder_database, self.resfinder_drug_table,
                                                self.cge_drug_table, blast_handler,
                                                self.pointfinder_drug_table, pointfinder_database,
-                                               output_dir=self.outdir.name, genes_to_exclude=['gyrA'])
+                                               output_dir=self.outdir.name, genes_to_exclude=['gyrA_1_MH933946.1'])
 
         file = path.join(self.test_data_dir, "16S_gyrA_beta-lactam.fsa")
         files = [file]
@@ -1115,9 +1115,9 @@ class AMRDetectionIT(unittest.TestCase):
         records = SeqIO.to_dict(SeqIO.parse(hit_file, 'fasta'))
         self.assertEqual(len(records), 2, 'Wrong number of hit records')
         expected_records1 = SeqIO.to_dict(SeqIO.parse(path.join(self.test_data_dir, 'gyrA-A67P.fsa'), 'fasta'))
-        self.assertEqual(expected_records1['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records1['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
         expected_records2 = SeqIO.to_dict(SeqIO.parse(path.join(self.test_data_dir, '16S_rrsD-1T1065.fsa'), 'fasta'))
-        self.assertEqual(expected_records2['16S_rrsD'].seq.upper(), records['16S_rrsD'].seq.upper(),
+        self.assertEqual(expected_records2['16S_rrsD'].seq.upper(), records['16S-rrsD_1_CP049983.1'].seq.upper(),
                          "records don't match")
 
     def testResfinderExcludeNonMatches(self):

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -476,7 +476,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
 
     def testPointfinderSalmonellaS83ISuccess(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -516,7 +516,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
 
     def testPointfinderSalmonellaA67PSuccessNoPhenotype(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -589,7 +589,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
 
     def testPointfinderSalmonellaA67PDelEndFailPlength(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -685,7 +685,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(path.join(self.test_data_dir, "gyrA-A67P.fsa"), 'fasta'))
-        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['gyrA'].seq.upper(), records['gyrA_1_MH933946.1'].seq.upper(), "records don't match")
 
     def testPointfinderSalmonella_16S_rrSD_C1065T_Success(self):
         pointfinder_database = PointfinderBlastDatabase(self.pointfinder_dir, 'salmonella')
@@ -1392,7 +1392,7 @@ class AMRDetectionIT(unittest.TestCase):
         pointfinder_results = amr_detection.get_pointfinder_results()
         self.assertEqual(len(pointfinder_results.index), 1, 'Wrong number of rows in result')
 
-        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter_size_53bp (C-42T)']
+        result = pointfinder_results[pointfinder_results['Gene'] == 'ampC_promoter (C-42T)']
         self.assertEqual(len(result.index), 1, 'Wrong number of results detected')
         self.assertEqual(result.index[0], 'ampC_promoter_size_53bp-Cn42T', msg='Wrong file')
         self.assertEqual(result['Type'].iloc[0], 'nucleotide', msg='Wrong type')
@@ -1410,7 +1410,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC_promoter_size_53bp'].seq.upper(), "records don't match")
+        self.assertEqual(expected_records['ampC_promoter_size_53bp'].seq.upper(), records['ampC-promoter_1_CP037449.1'].seq.upper(), "records don't match")
 
     def testPointfinderMycobacteriumTuberculosisF10ISuccess(self):
         # F10I
@@ -1611,7 +1611,7 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(len(records), 1, 'Wrong number of hit records')
 
         expected_records = SeqIO.to_dict(SeqIO.parse(file, 'fasta'))
-        self.assertEqual(expected_records['rpsE'].seq.upper(), records['rpsE'].seq.upper().replace('-', ''), "records don't match")
+        self.assertEqual(expected_records['rpsE'].seq.upper(), records['rpsE_1_AP023075.1'].seq.upper().replace('-', ''), "records don't match")
 
     def testPointfinderEnterococcusFaecium466insSSuccess(self):
         # Insert a AGC (S) at position 466 (codon coords).


### PR DESCRIPTION
It's important to note that it seems like CGE has been moving away from using the `resistens-overview.txt` files (and format) and have started using a new `phenotypes.txt` file. The support for `resistens-overview.txt` seems to be legacy-support only? I don't expect that this version of StarAMR will be able to support different versions of the database any longer.

Here's a list of some of the changes in this pull request to support updating to the new databases:

- Updating database commits.
- Allowing for 4 spaces in addition to tabs as a separator in the `resistens-overview.txt` file.
- Ignoring duplicate FASTA records added to the databases.
- Updating the mapping of FASTA record ID to AMR resistance table entries (they changed names to include accession IDs but didn't change `resistens-overview.txt` names; ex: `pmrA` -> `pmrA_1_CP055130.1`). This has had a lot of downstream consequences in our analysis.
- More thorough exception handling for parsing `16S`, `23S`, and promoter FASTA record ID names and corresponding gene ID names (related to the above point).
- Pandas updates.
- Testing updates.
- `pytest` is [preferred](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/) over `setup.py test`.

Some important changes that may affect users:

- Changed `ampC_promoter` entries in `ARG_drug_key_pointfinder.tsv` to match how promoters are being handled now.
- The ignore gene functionality (`ExcludeGenesList.py` and `genes_to_exclude.tsv`) now requires exactly matching the NEW CGE FASTA record ID format. For example: `gyrA` must now be something like `gyrA_1_MH933946.1` (depending on which species and specific gene).