### PR TITLE
Updating ARG Drug Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Removed ARG drug key entries with "None" or missing resistance.
+* The ARG drug key for salmonella acrB 717 has changed to acrB 171.
+
 # Version 0.10.0
 
 * Updated the Plasmidfinder database to use the January 18th 2023 release.

--- a/scripts/data-conversion/pointfinder-drug-resistance.ipynb
+++ b/scripts/data-conversion/pointfinder-drug-resistance.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['Salmonella', 'Shigella E. coli', 'Campylobacter'])"
+       "dict_keys(['Salmonella', 'Shigella E. coli', 'Campylobacter', 'NCBI AMRfinder'])"
       ]
      },
      "execution_count": 1,
@@ -28,7 +28,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "pointfinder_file = '../../drug-key-update/pointfinder 072621.xlsx'\n",
+    "pointfinder_file = '../../pointfinder.xlsx'\n",
     "\n",
     "pointfinder_excel = pd.ExcelFile(pointfinder_file)\n",
     "sheets_df_map_orig = {n: pd.read_excel(pointfinder_excel, sheet_name=n, header=None) for n in pointfinder_excel.sheet_names}\n",
@@ -407,6 +407,14 @@
    "source": [
     "pointfinder_df_reduced.to_csv('../../staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv', sep='\\t', index=False)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "938df9d4-d16a-4855-aee0-5208fadfad68",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -425,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/scripts/data-conversion/resfinder-drug-resistance.ipynb
+++ b/scripts/data-conversion/resfinder-drug-resistance.ipynb
@@ -10,17 +10,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "ba3db1bf-344d-40c7-a4d4-fb5dab85a822",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "dict_keys(['Aminoglycoside', 'B-lactam', 'Colistin', 'Fosfomycin', 'Fusidic acid', 'Glycopeptide', 'Macrolide', 'Nitroimidazole', 'Oxazolidinone', 'Phenicol', 'Quinolone', 'Rifampicin', 'Sulphonamide', 'Tetracycline', 'Trimethoprim', 'Non-functional'])"
+       "dict_keys(['Aminoglycoside', 'B-lactam', 'Colistin', 'Fosfomycin', 'Fusidic acid', 'Glycopeptide', 'Macrolide', 'Nitroimidazole', 'Oxazolidinone', 'Phenicol', 'Quinolone', 'Sulphonamide', 'Rifampicin', 'Tetracycline', 'Trimethoprim', 'Non-functional'])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -28,7 +28,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "resfinder_file = '../../drug-key-update/Resfinder 3.0 drug key 072621.xlsx'\n",
+    "resfinder_file = '../../resfinder.xlsx'\n",
     "\n",
     "resfinder_excel = pd.ExcelFile(resfinder_file)\n",
     "sheets_df_map_orig = {n: pd.read_excel(resfinder_excel, sheet_name=n, header=None) for n in resfinder_excel.sheet_names}\n",
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "247c35d5-3075-4a6f-aad8-c6da5b908b7b",
    "metadata": {},
    "outputs": [
@@ -109,7 +109,7 @@
        "2  aminoglycoside  aac(6')-30-aac(6')-Ib'_1_AJ584652  gentamicin  NaN"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "7ad1a1b3-e7a3-4617-94ce-cf4515f67fe1",
    "metadata": {},
    "outputs": [
@@ -211,7 +211,7 @@
        "2  NaN  NaN  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -233,40 +233,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "fb20e101-6ba9-4d7c-be25-6f3bac08ec07",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "                                                                                                                                                                                                                            3069\n",
+       "Other\n",
+       "                                                                                                                                                                                                                            3070\n",
        "formerly aadB                                                                                                                                                                                                                 19\n",
        "formerly aadE                                                                                                                                                                                                                  2\n",
-       "formerly strA                                                                                                                                                                                                                  2\n",
        "AMRfinderShig/Ecoeffluxchromosomal wildtype pump                                                                                                                                                                               2\n",
-       " formerly strA_2                                                                                                                                                                                                               1\n",
-       " formerly strA_3                                                                                                                                                                                                               1\n",
+       "formerly strA                                                                                                                                                                                                                  2\n",
+       "ResfinderSalmonellaaminoglycosidecryptic chromosomal wildtype gene, hidden                                                                                                                                                     1\n",
+       "AMRfinderEcocolistintwo-component system sensor histidine kinase, multiple genes involved, effects not known                                                                                                                   1\n",
+       "AMRfinderEcofosfomycinglycerol-3-phosphate transporter, drug not tested                                                                                                                                                        1\n",
        "Resfinder BNEcomacrolidesremoved from updated Resfinder                                                                                                                                                                        1\n",
        "Resfinder JessSal/Ecoeffluxdisinfectants                                                                                                                                                                                       1\n",
        "ResfinderShig/Ecoeffluxchromosomal wildtype pump, hidden                                                                                                                                                                       1\n",
        "AMRfindermultipleSTREPTOGRAMINdrug not tested                                                                                                                                                                                  1\n",
        "AMRfindermultipleQUATERNARY AMMONIUMdrug not tested, biocide                                                                                                                                                                   1\n",
        "AMRfindermultipleSTREPTOTHRICINdrug not tested                                                                                                                                                                                 1\n",
-       "ResfinderSalmonellaaminoglycosidecryptic chromosomal wildtype gene, hidden                                                                                                                                                     1\n",
+       "AMRfinderShig/Ecoeffluxchromosomal wildtype pump, similar to AR pump in Klebsiella, may be involved in biofilm formation                                                                                                       1\n",
        "ResfinderSalmonellaquinolonescommon mutation, little or no effect on MICs, hidden                                                                                                                                              1\n",
        "AMRfinderSalmonellaeffluxchromosomal wildtype pump, may be involved in virulence                                                                                                                                               1\n",
-       "AMRfinderShig/Ecoeffluxchromosomal wildtype pump, similar to AR pump in Klebsiella, may be involved in biofilm formation                                                                                                       1\n",
-       "formerly aadA4                                                                                                                                                                                                                 1\n",
        "AMRfinderShig/EcoB-lactamchromosomal wildtype gene, promoter mutations needed for function                                                                                                                                     1\n",
        "databaseorganismdrug classnotes                                                                                                                                                                                                1\n",
        "formerly strB_3                                                                                                                                                                                                                1\n",
        " formerly strA_4                                                                                                                                                                                                               1\n",
+       " formerly strA_3                                                                                                                                                                                                               1\n",
+       " formerly strA_2                                                                                                                                                                                                               1\n",
+       "formerly aadA4                                                                                                                                                                                                                 1\n",
        "*due to the higher breakpoints for some Enterobacteriaceae including shigella and E. coli, PMQRs are predicted to confer decreased susceptibility to fluoroquinolones but not intermediate susceptibility or resistance.       1\n",
-       "Name: Other, dtype: int64"
+       "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -291,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "1cbeebcf-cebb-4fb1-b063-b4bea7dc06cb",
    "metadata": {},
    "outputs": [
@@ -304,15 +307,15 @@
        "3                  aac(6')-Iaj_1_AB709942\n",
        "4                  aac(6')-Ian_1_AP014611\n",
        "                      ...                \n",
-       "3107                    dfrA17_6_AF180469\n",
-       "3108                    dfrA17_7_AB196349\n",
-       "3109                    dfrA17_8_AM932673\n",
-       "3110                    dfrA17_9_FJ807902\n",
-       "3111                   dfrA17_10_AM937244\n",
-       "Name: gene_accession, Length: 3112, dtype: object"
+       "3110                    dfrA17_6_AF180469\n",
+       "3111                    dfrA17_7_AB196349\n",
+       "3112                    dfrA17_8_AM932673\n",
+       "3113                    dfrA17_9_FJ807902\n",
+       "3114                   dfrA17_10_AM937244\n",
+       "Name: gene_accession, Length: 3115, dtype: object"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "52028c02-0f54-4fc0-844d-f77e971fce1f",
    "metadata": {},
    "outputs": [
@@ -398,35 +401,35 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3107</th>\n",
+       "      <th>3110</th>\n",
        "      <td>trimethoprim</td>\n",
        "      <td>dfrA17_6</td>\n",
        "      <td>AF180469</td>\n",
        "      <td>trimethoprim</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3108</th>\n",
+       "      <th>3111</th>\n",
        "      <td>trimethoprim</td>\n",
        "      <td>dfrA17_7</td>\n",
        "      <td>AB196349</td>\n",
        "      <td>trimethoprim</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3109</th>\n",
+       "      <th>3112</th>\n",
        "      <td>trimethoprim</td>\n",
        "      <td>dfrA17_8</td>\n",
        "      <td>AM932673</td>\n",
        "      <td>trimethoprim</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3110</th>\n",
+       "      <th>3113</th>\n",
        "      <td>trimethoprim</td>\n",
        "      <td>dfrA17_9</td>\n",
        "      <td>FJ807902</td>\n",
        "      <td>trimethoprim</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3111</th>\n",
+       "      <th>3114</th>\n",
        "      <td>trimethoprim</td>\n",
        "      <td>dfrA17_10</td>\n",
        "      <td>AM937244</td>\n",
@@ -434,7 +437,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>3098 rows × 4 columns</p>\n",
+       "<p>3099 rows × 4 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -445,16 +448,16 @@
        "3     aminoglycoside             aac(6')-Iaj_1  AB709942    gentamicin\n",
        "4     aminoglycoside             aac(6')-Ian_1  AP014611    gentamicin\n",
        "...              ...                       ...       ...           ...\n",
-       "3107    trimethoprim                  dfrA17_6  AF180469  trimethoprim\n",
-       "3108    trimethoprim                  dfrA17_7  AB196349  trimethoprim\n",
-       "3109    trimethoprim                  dfrA17_8  AM932673  trimethoprim\n",
-       "3110    trimethoprim                  dfrA17_9  FJ807902  trimethoprim\n",
-       "3111    trimethoprim                 dfrA17_10  AM937244  trimethoprim\n",
+       "3110    trimethoprim                  dfrA17_6  AF180469  trimethoprim\n",
+       "3111    trimethoprim                  dfrA17_7  AB196349  trimethoprim\n",
+       "3112    trimethoprim                  dfrA17_8  AM932673  trimethoprim\n",
+       "3113    trimethoprim                  dfrA17_9  FJ807902  trimethoprim\n",
+       "3114    trimethoprim                 dfrA17_10  AM937244  trimethoprim\n",
        "\n",
-       "[3098 rows x 4 columns]"
+       "[3099 rows x 4 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,7 +488,7 @@
     "resfinder_df['Drug'] = resfinder_df['Drug'].str.strip()\n",
     "\n",
     "# Now, get rid of spaces and replace with commas\n",
-    "resfinder_df['Drug'] = resfinder_df['Drug'].str.replace('\\s+', ',', regex=True)\n",
+    "resfinder_df['Drug'] = resfinder_df['Drug'].str.replace(r'\\s+', ',', regex=True)\n",
     "\n",
     "# Now fix up specific cases where there should be spaces\n",
     "resfinder_df['Drug'] = resfinder_df['Drug'].str.replace(',acid', ' acid')\n",
@@ -507,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "44663836-3cb9-49e4-bd78-2466a782d3d3",
    "metadata": {},
    "outputs": [
@@ -570,7 +573,7 @@
        "151  NaN  NaN  NaN  NaN        aac(6')-IIc_1  NC_012555  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,13 +593,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "be0dddd6-92db-4720-9632-3ccfa5bfbd7a",
    "metadata": {},
    "outputs": [],
    "source": [
     "resfinder_df.to_csv('../../staramr/databases/resistance/data/ARG_drug_key_resfinder.tsv', sep='\\t', index=False)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36e8944e-6acc-4fa7-9424-8d51c657644f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -615,7 +626,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -47,73 +47,73 @@ salmonella	parE	514	ciprofloxacin I/R,nalidixic acid
 salmonella	parE	521	ciprofloxacin I/R,nalidixic acid
 salmonella	16S_rrsD	1065	spectinomycin
 salmonella	16S_rrsD	1192	spectinomycin
-salmonella	parC	57	None
-salmonella	acrB	717	azithromycin
-escherichia_coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrB	136	aminocoumarin
-escherichia_coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	56	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	57	None
-escherichia_coli	parC	60	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	78	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	80	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	84	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	108	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	416	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	423	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	439	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	444	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	458	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	460	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	464	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	470	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	475	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	476	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parE	529	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	pmrA	39	colistin
-escherichia_coli	pmrA	81	colistin
-escherichia_coli	pmrB	161	colistin
-escherichia_coli	folP	64	sulfisoxazole
-escherichia_coli	rpoB	146	rifamycin
-escherichia_coli	rpoB	513	rifamycin
-escherichia_coli	rpoB	526	rifamycin
-escherichia_coli	rpoB	529	rifamycin
-escherichia_coli	rpoB	531	rifamycin
-escherichia_coli	rpoB	533	rifamycin
-escherichia_coli	rpoB	563	rifamycin
-escherichia_coli	rpoB	564	rifamycin
-escherichia_coli	rpoB	687	rifamycin
-escherichia_coli	23S	2059	erythromycin,azithromycin
-escherichia_coli	16S_rrsB	523	streptomycin
-escherichia_coli	16S_rrsB	527	streptomycin
-escherichia_coli	16S_rrsB	528	streptomycin
-escherichia_coli	16S_rrsB	964	tetracycline
-escherichia_coli	16S_rrsB	1053	tetracycline
-escherichia_coli	16S_rrsB	1054	tetracycline
-escherichia_coli	16S_rrsB	1055	tetracycline
-escherichia_coli	16S_rrsB	1058	tetracycline
-escherichia_coli	16S_rrsB	1064	spectinomycin
-escherichia_coli	16S_rrsB	1066	spectinomycin
-escherichia_coli	16S_rrsB	1068	spectinomycin
-escherichia_coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
-escherichia_coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
-escherichia_coli	16S_rrsC	794	kasugamicin
-escherichia_coli	16S_rrsC	926	kasugamicin
-escherichia_coli	16S_rrsC	1519	kasugamicin
-escherichia_coli	16S_rrsH	1192	spectinomycin
-escherichia_coli	ampC_promoter	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-escherichia_coli	ampC_promoter	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+salmonella	parC	57	
+salmonella	acrB	171	azithromycin
+e.coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrB	136	aminocoumarin
+e.coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
+e.coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	56	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	57	
+e.coli	parC	60	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	78	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	80	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	84	ciprofloxacin I/R,nalidixic acid
+e.coli	parC	108	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	416	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	423	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	439	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	444	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	458	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	460	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	464	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	470	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	475	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	476	ciprofloxacin I/R,nalidixic acid
+e.coli	parE	529	ciprofloxacin I/R,nalidixic acid
+e.coli	pmrA	39	colistin
+e.coli	pmrA	81	colistin
+e.coli	pmrB	161	colistin
+e.coli	folP	64	sulfisoxazole
+e.coli	rpoB	146	rifamycin
+e.coli	rpoB	513	rifamycin
+e.coli	rpoB	526	rifamycin
+e.coli	rpoB	529	rifamycin
+e.coli	rpoB	531	rifamycin
+e.coli	rpoB	533	rifamycin
+e.coli	rpoB	563	rifamycin
+e.coli	rpoB	564	rifamycin
+e.coli	rpoB	687	rifamycin
+e.coli	23S	2059	erythromycin,azithromycin
+e.coli	16S_rrsB	523	streptomycin
+e.coli	16S_rrsB	527	streptomycin
+e.coli	16S_rrsB	528	streptomycin
+e.coli	16S_rrsB	964	tetracycline
+e.coli	16S_rrsB	1053	tetracycline
+e.coli	16S_rrsB	1054	tetracycline
+e.coli	16S_rrsB	1055	tetracycline
+e.coli	16S_rrsB	1058	tetracycline
+e.coli	16S_rrsB	1064	spectinomycin
+e.coli	16S_rrsB	1066	spectinomycin
+e.coli	16S_rrsB	1068	spectinomycin
+e.coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
+e.coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
+e.coli	16S_rrsC	794	kasugamicin
+e.coli	16S_rrsC	926	kasugamicin
+e.coli	16S_rrsC	1519	kasugamicin
+e.coli	16S_rrsH	1192	spectinomycin
+e.coli	ampC_promoter_size_53bp	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter_size_53bp	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter_size_53bp	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter_size_53bp	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 campylobacter	gyrA	70	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	85	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	86	ciprofloxacin,nalidixic acid

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -110,10 +110,10 @@ e.coli	16S_rrsC	794	kasugamicin
 e.coli	16S_rrsC	926	kasugamicin
 e.coli	16S_rrsC	1519	kasugamicin
 e.coli	16S_rrsH	1192	spectinomycin
-e.coli	ampC_promoter_size_53bp	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter_size_53bp	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+e.coli	ampC_promoter	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 campylobacter	gyrA	70	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	85	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	86	ciprofloxacin,nalidixic acid

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -49,71 +49,71 @@ salmonella	16S_rrsD	1065	spectinomycin
 salmonella	16S_rrsD	1192	spectinomycin
 salmonella	parC	57	
 salmonella	acrB	171	azithromycin
-e.coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrB	136	aminocoumarin
-e.coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
-e.coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	56	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	57	
-e.coli	parC	60	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	78	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	80	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	84	ciprofloxacin I/R,nalidixic acid
-e.coli	parC	108	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	416	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	423	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	439	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	444	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	458	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	460	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	464	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	470	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	475	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	476	ciprofloxacin I/R,nalidixic acid
-e.coli	parE	529	ciprofloxacin I/R,nalidixic acid
-e.coli	pmrA	39	colistin
-e.coli	pmrA	81	colistin
-e.coli	pmrB	161	colistin
-e.coli	folP	64	sulfisoxazole
-e.coli	rpoB	146	rifamycin
-e.coli	rpoB	513	rifamycin
-e.coli	rpoB	526	rifamycin
-e.coli	rpoB	529	rifamycin
-e.coli	rpoB	531	rifamycin
-e.coli	rpoB	533	rifamycin
-e.coli	rpoB	563	rifamycin
-e.coli	rpoB	564	rifamycin
-e.coli	rpoB	687	rifamycin
-e.coli	23S	2059	erythromycin,azithromycin
-e.coli	16S_rrsB	523	streptomycin
-e.coli	16S_rrsB	527	streptomycin
-e.coli	16S_rrsB	528	streptomycin
-e.coli	16S_rrsB	964	tetracycline
-e.coli	16S_rrsB	1053	tetracycline
-e.coli	16S_rrsB	1054	tetracycline
-e.coli	16S_rrsB	1055	tetracycline
-e.coli	16S_rrsB	1058	tetracycline
-e.coli	16S_rrsB	1064	spectinomycin
-e.coli	16S_rrsB	1066	spectinomycin
-e.coli	16S_rrsB	1068	spectinomycin
-e.coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
-e.coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
-e.coli	16S_rrsC	794	kasugamicin
-e.coli	16S_rrsC	926	kasugamicin
-e.coli	16S_rrsC	1519	kasugamicin
-e.coli	16S_rrsH	1192	spectinomycin
-e.coli	ampC_promoter	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-e.coli	ampC_promoter	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	81	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	82	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	83	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	84	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	87	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	106	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrA	196	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrB	136	aminocoumarin
+escherichia_coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	56	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	57	
+escherichia_coli	parC	60	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	78	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	80	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	84	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parC	108	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	416	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	423	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	439	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	444	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	458	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	460	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	464	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	470	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	475	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	476	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	parE	529	ciprofloxacin I/R,nalidixic acid
+escherichia_coli	pmrA	39	colistin
+escherichia_coli	pmrA	81	colistin
+escherichia_coli	pmrB	161	colistin
+escherichia_coli	folP	64	sulfisoxazole
+escherichia_coli	rpoB	146	rifamycin
+escherichia_coli	rpoB	513	rifamycin
+escherichia_coli	rpoB	526	rifamycin
+escherichia_coli	rpoB	529	rifamycin
+escherichia_coli	rpoB	531	rifamycin
+escherichia_coli	rpoB	533	rifamycin
+escherichia_coli	rpoB	563	rifamycin
+escherichia_coli	rpoB	564	rifamycin
+escherichia_coli	rpoB	687	rifamycin
+escherichia_coli	23S	2059	erythromycin,azithromycin
+escherichia_coli	16S_rrsB	523	streptomycin
+escherichia_coli	16S_rrsB	527	streptomycin
+escherichia_coli	16S_rrsB	528	streptomycin
+escherichia_coli	16S_rrsB	964	tetracycline
+escherichia_coli	16S_rrsB	1053	tetracycline
+escherichia_coli	16S_rrsB	1054	tetracycline
+escherichia_coli	16S_rrsB	1055	tetracycline
+escherichia_coli	16S_rrsB	1058	tetracycline
+escherichia_coli	16S_rrsB	1064	spectinomycin
+escherichia_coli	16S_rrsB	1066	spectinomycin
+escherichia_coli	16S_rrsB	1068	spectinomycin
+escherichia_coli	16S_rrsB	1406	gentamicin,kanamycin,tobramycin
+escherichia_coli	16S_rrsB	1408	gentamicin,kanamycin,neomycin,paromomycin
+escherichia_coli	16S_rrsC	794	kasugamicin
+escherichia_coli	16S_rrsC	926	kasugamicin
+escherichia_coli	16S_rrsC	1519	kasugamicin
+escherichia_coli	16S_rrsH	1192	spectinomycin
+escherichia_coli	ampC_promoter	-42	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-32	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-13	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+escherichia_coli	ampC_promoter	-12	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 campylobacter	gyrA	70	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	85	ciprofloxacin,nalidixic acid
 campylobacter	gyrA	86	ciprofloxacin,nalidixic acid

--- a/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_pointfinder.tsv
@@ -47,7 +47,6 @@ salmonella	parE	514	ciprofloxacin I/R,nalidixic acid
 salmonella	parE	521	ciprofloxacin I/R,nalidixic acid
 salmonella	16S_rrsD	1065	spectinomycin
 salmonella	16S_rrsD	1192	spectinomycin
-salmonella	parC	57	
 salmonella	acrB	171	azithromycin
 escherichia_coli	gyrA	51	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	gyrA	67	ciprofloxacin I/R,nalidixic acid
@@ -62,7 +61,6 @@ escherichia_coli	gyrB	136	aminocoumarin
 escherichia_coli	gyrB	426	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	gyrB	447	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	parC	56	ciprofloxacin I/R,nalidixic acid
-escherichia_coli	parC	57	
 escherichia_coli	parC	60	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	parC	78	ciprofloxacin I/R,nalidixic acid
 escherichia_coli	parC	80	ciprofloxacin I/R,nalidixic acid

--- a/staramr/databases/resistance/data/ARG_drug_key_resfinder.tsv
+++ b/staramr/databases/resistance/data/ARG_drug_key_resfinder.tsv
@@ -125,7 +125,7 @@ aminoglycoside	aac(3)-Xa_1	AB028210	amikacin
 aminoglycoside	aac(6')-Ia_1	M18967	amikacin,tobramycin
 aminoglycoside	aac(6')-Ib_1	M21682	amikacin,gentamicin,kanamycin
 aminoglycoside	aac(6')-Ic_1	M94066	amikacin,tobramycin
-aminoglycoside	aac(6')-If_1	X55353	amikacin,kanamycin
+aminoglycoside	aac(6')-If_1	X55353	tobramycin,dibekacin,amikacin,sisomicin,netilmicin
 aminoglycoside	aac(6')-Ig_1	L09246	amikacin,tobramycin
 aminoglycoside	aac(6')-Ih_1	L29044	amikacin,tobramycin
 aminoglycoside	aac(6')-Ij_1	L29045	amikacin,tobramycin
@@ -155,7 +155,7 @@ aminoglycoside	aac(6')-aph(2'')_1	M13771	amikacin,gentamicin,tobramycin
 aminoglycoside	aac(6')-Isa_1	AB116646	amikacin,tobramycin
 aminoglycoside	aac(6')-Ib3_1	X60321	amikacin,tobramycin
 aminoglycoside	aacA43_1	HQ247816	amikacin,tobramycin
-aminoglycoside	ant(3'')-Ia_1	X02340	spectinomycin
+aminoglycoside	ant(3'')-Ia_1	X02340	streptomycin
 aminoglycoside	aadA1_2	FJ591054	streptomycin
 aminoglycoside	aadA1_3	JQ414041	streptomycin
 aminoglycoside	aadA1b_1	M95287	streptomycin
@@ -251,35 +251,142 @@ aminoglycoside	aac(3)-IIa_4	L22613	gentamicin,tobramycin
 aminoglycoside	aac(3)-IIa_5	FJ012882	gentamicin,tobramycin
 aminoglycoside	aac(3)-IV_1	DQ241380	gentamicin,tobramycin
 aminoglycoside	aac(3)-VIa_2	NC_009838	gentamicin
-aminoglycoside	aph(3')-Ib_2	AJ744860	None
-aminoglycoside	ant(9)-Ia_2	M69221	None
+aminoglycoside	aph(3')-Ib_2	AJ744860	
+aminoglycoside	ant(9)-Ia_2	M69221	
 aminoglycoside	aadA24_1	DQ677333	streptomycin
 aminoglycoside	aadA8b_1	AY139603	streptomycin
 aminoglycoside	aadA2b_1	D43625	streptomycin
 aminoglycoside	aac(6')-Ii_1	L12710	amikacin,tobramycin
-aminoglycoside	aac(3)-XI_1	CTEG01000046	None
-aminoglycoside	aac(3)-VIII_1	AB211959	None
-aminoglycoside	aac(3)-VIII_2	AJ843080	None
-aminoglycoside	aac(3)-VIII_3	AJ748131	None
+aminoglycoside	aac(3)-XI_1	CTEG01000046	
+aminoglycoside	aac(3)-VIII_1	AB211959	
+aminoglycoside	aac(3)-VIII_2	AJ843080	
+aminoglycoside	aac(3)-VIII_3	AJ748131	
 aminoglycoside	kmr_1_ENA	ACB88605	amikacin,gentamicin,tobramycin
 aminoglycoside	aadD_2	M19465	amikacin,tobramycin
+beta-lactam	ampH_1	AJ276031	ampicillin
+beta-lactam	ampH_2	HQ586946	ampicillin
+beta-lactam	ampS_1	X80276	ampicillin
+beta-lactam	blaA_1	DQ424965	ampicillin
+beta-lactam	blaA_2	AY954728	ampicillin
 beta-lactam	blaACC-1_1	AJ133121	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACC-1_2	HG530658	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-1a_1	AF180953	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-1b_1	AF180955	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-1c_1	AF180959	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-1d_1	ADCU02000001	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACC-2_1	AF180952	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACC-3_1	AF180958	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACC-4_1	GU256641	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACC-4_1	KM087831	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-4_2	EF504260	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-5_1	HE819401	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaACC-7_1	MG028657	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACI-1_1	AJ007350	ampicillin
+beta-lactam	blaACT-1_1	U58495	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-10_1	JN848330	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-12_1	JX440355	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-14_1	JX440354	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-15_1	JX440356	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-16_1	AB737978	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-2_1	AM076977	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-3_1	EF125013	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-4_2	AJ311172	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-5_1	FJ237369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-6_1	FJ237366	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-7_1	FJ237368	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaACT-9_1	HQ693810	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaADC-25_1	EF016355	ampicillin
+beta-lactam	blaAER-1_1	U14748	ampicillin
+beta-lactam	blaAST-1_1	AF279904	ampicillin
+beta-lactam	blaB-10_1	AY348325	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-11_1	AY348326	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-12_1	EF595958	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-13_1	EF595959	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-14_1	JN635697	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-2_1	AF189300	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-3_1	AF189301	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-3_2	AF189299	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-5_1	AF189303	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-6_1	AF189302	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-7_1	AF189304	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-8_1	AF189305	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaB-9_1	AY348324	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaBEL-1_1	DQ089809	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaBEL-2_1	FJ666063	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaBEL-3_1	GQ202694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaBES-1_1	AF234999	ampicillin
+beta-lactam	blaBIC-1_1	GQ260093	ampicillin
+beta-lactam	blaBIL-1_1	X74512	ampicillin
+beta-lactam	blaBKC-1_1	KP689347	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaBRO-1_1	Z54180	ampicillin
+beta-lactam	blaBRO-2_1	Z54181	ampicillin
+beta-lactam	blaCARB-1_1	AF313471	ampicillin
+beta-lactam	blaCARB-10_1	EU850412	ampicillin
+beta-lactam	blaCARB-11_1	AY008290	ampicillin
+beta-lactam	blaCARB-12_1	D13210	ampicillin
+beta-lactam	blaCARB-14_1	JQ364968	ampicillin
+beta-lactam	blaCARB-16_1	HF953351	ampicillin
+beta-lactam	blaCARB-17_1	KJ934265	ampicillin
+beta-lactam	blaCARB-18_1	KJ934266	ampicillin
+beta-lactam	blaCARB-19_1	KJ934267	ampicillin
+beta-lactam	blaCARB-2_1	M69058	ampicillin
+beta-lactam	blaCARB-20_1	NG_054946	ampicillin
+beta-lactam	blaCARB-21_1	NG_048724	ampicillin
+beta-lactam	blaCARB-22_1	JYNG01000059	ampicillin
+beta-lactam	blaCARB-23_1	NG_048726	ampicillin
+beta-lactam	blaCARB-24_1	BK008907	ampicillin
+beta-lactam	blaCARB-25_1	BK008888	ampicillin
+beta-lactam	blaCARB-26_1	BK008904	ampicillin
+beta-lactam	blaCARB-27_1	NG_048730	ampicillin
+beta-lactam	blaCARB-28_1	BK008906	ampicillin
+beta-lactam	blaCARB-29_1	BK008905	ampicillin
+beta-lactam	blaCARB-3_1	S46063	ampicillin
+beta-lactam	blaCARB-30_1	NG_048734	ampicillin
+beta-lactam	blaCARB-31_1	NG_048735	ampicillin
+beta-lactam	blaCARB-32_1	NG_048736	ampicillin
+beta-lactam	blaCARB-33_1	BK008903	ampicillin
+beta-lactam	blaCARB-34_1	NG_048738	ampicillin
+beta-lactam	blaCARB-35_1	BK008900	ampicillin
+beta-lactam	blaCARB-36_1	LHBD01000022	ampicillin
+beta-lactam	blaCARB-38_1	BK008898	ampicillin
+beta-lactam	blaCARB-4_1	FJ785525	ampicillin
+beta-lactam	blaCARB-40_1	BK008889	ampicillin
+beta-lactam	blaCARB-41_1	BK008890	ampicillin
+beta-lactam	blaCARB-42_1	NG_048745	ampicillin
+beta-lactam	blaCARB-43_1	NG_048746	ampicillin
+beta-lactam	blaCARB-44_1	JTGS01000066	ampicillin
+beta-lactam	blaCARB-45_1	JTGR01000061	ampicillin
+beta-lactam	blaCARB-46_1	NG_048749	ampicillin
+beta-lactam	blaCARB-47_1	NG050564	ampicillin
+beta-lactam	blaCARB-48_1	NG050604	ampicillin
+beta-lactam	blaCARB-49_1	KX599396	ampicillin
+beta-lactam	blaCARB-5_1	AF135373	ampicillin
+beta-lactam	blaCARB-50_1	NG_052478	ampicillin
+beta-lactam	blaCARB-6_1	AF030945	ampicillin
+beta-lactam	blaCARB-7_1	AF409092	ampicillin
+beta-lactam	blaCARB-8_1	AY178993	ampicillin
+beta-lactam	blaCARB-9_1	AY248038	ampicillin
+beta-lactam	blaCEPH-A3_1	AY112998	ampicillin
+beta-lactam	blaCFE-1_1	AB107899	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCGB-1_1	EF672680	ampicillin
+beta-lactam	blaCKO-1_1	AF477396	ampicillin
+beta-lactam	blaCME-1_1	AJ006275	ampicillin
+beta-lactam	blaCMG_1	AY265892	ampicillin
+beta-lactam	blaCMH-3_1	KX192165	ampicillin
+beta-lactam	blaCMY-1_1	X92508	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-10_1	AF381615	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-100_1	KF526113	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-101_1	KF526114	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-102_1	KF526115	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-103_1	KF526116	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-104_1	KF150216	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-105_1	KJ207205	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-106_1	KM983294	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-107_1	GQ162215	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-108_1	KF564648	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-109_1	AJ746169	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-11_1	AF357599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-110_1	AB872957	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-111_1	KJ155695	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-112_1	KM087837	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-113_1	KM087836	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
@@ -289,6 +396,7 @@ beta-lactam	blaCMY-116_1	KM087840	ampicillin,amoxicillin/clavulanic acid,cefoxit
 beta-lactam	blaCMY-117_1	KM087844	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-118_1	KM087838	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-119_1	KM087845	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-12_1	Y16785	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-121_1	KM507172	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-122_1	KM985460	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-124_1	KM985462	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
@@ -296,6 +404,7 @@ beta-lactam	blaCMY-125_1	KM985463	ampicillin,amoxicillin/clavulanic acid,cefoxit
 beta-lactam	blaCMY-127_1	KM985465	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-128_1	KM985466	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-129_1	KM985467	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-13_1	AY339625	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-130_1	KP207589	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-131_1	KP281294	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-132_1	KP862820	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
@@ -304,6 +413,7 @@ beta-lactam	blaCMY-134_1	KP860987	ampicillin,amoxicillin/clavulanic acid,cefoxit
 beta-lactam	blaCMY-135_1	KP981366	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-138_1	KT997883	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-139_1	KU641016	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-14_1	AJ555825	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-140_1	KX354367	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-141_1	KX537750	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-142_1	KX881969	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
@@ -314,6 +424,7 @@ beta-lactam	blaCMY-146_1	KX034085	ampicillin,amoxicillin/clavulanic acid,cefoxit
 beta-lactam	blaCMY-147_1	KY563765	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-148_1	KY624573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-149_1	KY624574	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-15_1	AJ555823	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-150_1	QCWX01000028	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-151_1	KY780116	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-152_1	KY978224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
@@ -321,27 +432,136 @@ beta-lactam	blaCMY-153_1	MF042206	ampicillin,amoxicillin/clavulanic acid,cefoxit
 beta-lactam	blaCMY-154_1	MF196231	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-155_1	KR261698	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-156_1	MF770636	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-16_1	AJ781421	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-17_1	AY513266	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-18_1	AY743434	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-19_1	AB194410	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-2_1	X91840	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-20_1	AY960293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-21_1	DQ139328	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-22_1	DQ256079	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-23_1	DQ438952	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-24_1	EF415650	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-25_1	EU515249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-26_1	AB300358	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-27_1	EU515250	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-28_1	EF561644	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-29_1	EF685371	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-2b_1	U77414	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-30_1	LMYO01000054	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-31_1	EF622224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-32_1	EU496815	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-33_1	EU496816	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-34_1	EF394370	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-35_1	EF394371	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-36_1	EU331426	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-37_1	AB280919	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-38_1	AM931008	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-39_1	AB372224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-4_1	LNHZ01000079	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-40_1	EU515251	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-41_1	AB429270	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-42_1	HM146927	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-43_1	FJ360626	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-44_1	FJ437066	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-45_1	FN546177	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-46_1	FN556186	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-47_1	HM046998	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-48_1	HM569226	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-49_1	GQ402541	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-5_1	Y17716	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-50_1	FN645444	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-51_1	JQ733571	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-53_1	HQ336940	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-54_1	HM544039	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-55_1	HM544040	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-56_1	HQ322613	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-57_1	HQ285243	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-58_1	HQ185697	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-59_1	NG_048854	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-6_1	AJ011293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-60_1	JF460794	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-61_1	JF460795	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-62_1	JF460796	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-63_1	HQ650104	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-64_1	HQ832678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-65_1	JF780936	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-66_1	JN714478	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-67_1	JQ711185	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-68_1	JN714480	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-69_1	JX049132	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-7_1	DQ173300	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-70_1	JX440350	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-71_1	JQ711184	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-72_1	JX440352	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-73_1	GQ351345	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-74_1	JX440349	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-75_1	JQ733572	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-76_1	JQ733573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-77_1	JX440353	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-78_1	JQ733575	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-79_1	JQ733576	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-8_1	AB201268	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-80_1	JQ733577	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-81_1	JQ733578	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-82_1	KJ207203	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-83_1	JX440351	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-84_1	JQ733579	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-85_1	KJ207202	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-86_1	KJ207204	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-87_1	AB699171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-89_1	HE819403	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-8b_1	DQ094251	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-9_1	AB061794	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-90_1	HE819404	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-93_1	KF992025	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-94_1	JX514368	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-95_1	JX514369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-96_1	KC007362	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCMY-97_1	KC007363	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-98_1	KC603538	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaCMY-99_1	KF305673	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
 beta-lactam	blaCTX-M-1_1	DQ915955	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-10_1	AY598759	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-100_1	FR682582	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-101_1	HQ398214	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-102_1	HQ398215	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-103_1	HG423149	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-104_1	HQ833652	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-105_1	HQ833651	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-110_1	JF274242	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-111_1	JF274243	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-112_1	JF274246	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-113_1	JF274247	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-114_1	GQ351346	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-116_1	JF966749	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-117_1	JN227085	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-12_1	DQ821704	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-121_1	JN790862	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-122_1	JN790863	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-123_1	JN790864	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-124_1	JQ429324	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-125_1	JQ724542	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-126_1	AB703103	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-127_1	MF196229	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-129_1	JX017364	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-13_2	AF252623	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-130_1	JX017365	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-131_1	JN969893	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-132_1	JX313020	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-134_1	JX896165	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-136_1	KC351754	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-137_1	KF790923	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-138_1	KF526119	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-139_1	KC107824	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-14_1	AF252622	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-141_1	KC964871	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-142_1	KF240809	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-144_1	KJ020573	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-146_1	KY938173	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-147_1	KF513180	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-148_1	KJ020574	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-14b_1	DQ359215	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-15_1	AY044436	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-150_1	KF769131	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-151_1	AB916359	ampicillin,ceftriaxone
@@ -350,6 +570,7 @@ beta-lactam	blaCTX-M-156_1	KM211509	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-157_1	KM211510	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-158_1	KM211691	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-159_1	AB976602	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-16_1	AY029068	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-160_1	KP050493	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-161_1	KP128034	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-162_1	KP681697	ampicillin,ceftriaxone
@@ -360,6 +581,7 @@ beta-lactam	blaCTX-M-166_1	KU978909	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-167_1	KR537428	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-168_1	KR537429	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-169_1	KR779864	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-17_1	AY033516	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-170_1	KR822223	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-171_1	KT277545	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-172_1	KT251041	ampicillin,ceftriaxone
@@ -377,6 +599,7 @@ beta-lactam	blaCTX-M-184_1	KX263247	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-186_1	KX446939	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-188_1	KX676491	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-189_1	FJ657512	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-19_1	AF325134	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-190_1	KX664469	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-191_1	KY271097	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-192_1	KY271098	ampicillin,ceftriaxone
@@ -387,6 +610,8 @@ beta-lactam	blaCTX-M-196_1	KY563769	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-197_1	KY646303	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-198_1	KY646304	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-199_1	KY786032	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-2_1	AB176535	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-20_1	AJ416344	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-200_1	KY997188	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-201_1	KY997189	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-202_1	MF195067	ampicillin,ceftriaxone
@@ -396,6 +621,7 @@ beta-lactam	blaCTX-M-206_1	KJ802520	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-207_1	LC348384	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-208_1	MH067958	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-209_1	MH067959	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-21_1	AJ416346	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-210_1	MH067960	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-211_1	MH067961	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-212_1	MH067962	ampicillin,ceftriaxone
@@ -405,13 +631,92 @@ beta-lactam	blaCTX-M-216_1	MH243352	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-217_1	MH243354	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-218_1	MH243358	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-219_1	CP019080	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-22_1	AY080894	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-220_1	MH450163	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-23_1	AF488377	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-24_1	EF374096	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-25_1	AF518567	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-26_1	AY157676	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-27_1	AY156923	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-28_6	AJ549244	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-29_1	AY267213	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-3_1	Y10278	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-30_1	AY292654	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-31_1	AJ567481	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-32_2	AJ557142	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-33_1	AY238472	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-34_1	AY515297	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-35_1	AB176532	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-36_1	AB177384	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-37_1	AY649755	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-38_1	AY822595	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-39_1	AY954516	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-4_1	Y14156	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-40_1	AY750914	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-41_1	DQ023162	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-42_1	DQ061159	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-43_1	DQ102702	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-44_1	D37830	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-46_1	AY847147	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-47_1	AY847143	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-48_1	AY847144	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-49_1	AY847145	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-5_1	U95364	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-50_1	AY847146	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-51_1	DQ211987	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-52_1	DQ223685	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-53_1	DQ268764	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-54_1	DQ303459	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-55_1	DQ810789	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-56_1	EF374097	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-58_1	EF210159	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-59_1	DQ408762	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-6_1	AJ005044	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-60_1	AM411407	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-61_1	EF219142	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-62_1	EF219134	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-63_1	AB205197	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-63_1	EU660216	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-64_1	AB284167	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-65_1	EF418608	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-66_1	EF576988	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-67_1	EF581888	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-68_1	EU177100	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-69_1	EU402393	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-7_1	AJ005045	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-71_1	FJ815436	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-72_1	AY847148	ampicillin,ceftriaxone
 beta-lactam	blaCTX-M-73_1	DQ343292	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-74_1	GQ149243	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-75_1	GQ149244	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-76_1	AM982520	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-77_1	AM982521	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-78_1	AM982522	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-79_1	EF426798	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-8_1	AF189721	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-80_1	EU202673	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-81_1	EU136031	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-82_1	DQ256091	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-83_1	FJ214366	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-84_1	FJ214367	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-85_1	FJ214368	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-86_1	FJ214369	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-87_1	EU545409	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-88_1	FJ873739	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-89_1	FJ971899	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-9_1	AF174129	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-90_1	FJ907381	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-91_1	GQ870432	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-92_1	GU127598	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-93_1	HQ166709	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-94_1	HM167760	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-95_1	FN813245	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-96_1	AJ704396	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-97_1	HM776707	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-98_1	HM755448	ampicillin,ceftriaxone
+beta-lactam	blaCTX-M-99_1	HM803271	ampicillin,ceftriaxone
+beta-lactam	blaDES-1_1	AF426161	ampicillin
+beta-lactam	blaDHA-1_1	Y16410	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-10_1	KP050490	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-12_1	HG798963	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-13_1	KM087855	ampicillin,amoxicillin/clavulanic acid,cefoxitin
@@ -421,6 +726,7 @@ beta-lactam	blaDHA-16_1	KM087852	ampicillin,amoxicillin/clavulanic acid,cefoxiti
 beta-lactam	blaDHA-17_1	KM087850	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-18_1	KM087841	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-19_1	KM087849	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDHA-2_1	AF259520	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-20_1	KM087848	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-21_1	KM087847	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-22_1	KM087856	ampicillin,amoxicillin/clavulanic acid,cefoxitin
@@ -429,22 +735,144 @@ beta-lactam	blaDHA-24_1	KU759569	ampicillin,amoxicillin/clavulanic acid,cefoxiti
 beta-lactam	blaDHA-25_1	KY563770	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-26_1	MH067966	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-27_1	MH067965	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDHA-3_1	AY494945	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-4_1	CP026046	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDHA-5_1	JF273491	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDHA-6_1	HQ322612	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDHA-7_1	HQ456945	ampicillin,amoxicillin/clavulanic acid,cefoxitin
 beta-lactam	blaDHA-9_1	KJ207201	ampicillin,amoxicillin/clavulanic acid,cefoxitin
+beta-lactam	blaDIM-1_1	GU323019	ampicillin
+beta-lactam	blaEBR-1_1	AF416700	ampicillin
+beta-lactam	blaERP-1_1	AY077733	ampicillin
+beta-lactam	blaFAR-1_1	AF024601	ampicillin
+beta-lactam	blaFONA-1_1	AJ251239	ampicillin
+beta-lactam	blaFONA-2_1	AJ251240	ampicillin
+beta-lactam	blaFONA-3_1	AJ251241	ampicillin
+beta-lactam	blaFONA-4_1	AJ251242	ampicillin
+beta-lactam	blaFONA-5_1	AJ251243	ampicillin
+beta-lactam	blaFONA-6_1	AJ251244	ampicillin
+beta-lactam	blaFOX-1_1	X77455	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-10_1	JX049131	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-2_1	Y10282	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-3_1	Y11068	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-4_1	AJ277535	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-5_1	AY007369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-6_1	AY034848	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-7_1	AJ703796	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-8_1	HM565917	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFOX-9_1	JF896803	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaFRI-1_1	KT192551	ampicillin,meropenem
+beta-lactam	blaFRI-1_1	KT192551	ampicillin,meropenem
+beta-lactam	blaFRI-2_1	KX620467	ampicillin,meropenem
+beta-lactam	blaFRI-3_1	KY524440	ampicillin,meropenem
+beta-lactam	blaFRI-4_1	NG_055267	ampicillin,meropenem
+beta-lactam	blaFRI-5_1	MH208723	ampicillin,meropenem
+beta-lactam	blaGES-1_1	HQ170511	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-10_1	FJ820124	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-11_1	FJ854362	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-12_1	FN554543	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-13_1	GU169702	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-14_1	GU207844	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-15_1	GU208678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-16_1	HM173356	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-17_1	HQ874631	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-18_1	JQ028729	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-19_1	JN596280	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-2_1	AF326355	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-20_1	JN596280	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-21_1	JQ772478	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-22_1	JX023441	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-23_1	KF179354	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-3_1	AB113580	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-4_1	AB116723	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-5_1	DQ236171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-6_1	AY494718	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-7_1	HM453325	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-8_1	AF329699	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGES-9_1	AY920928	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGIM-1_1	JF414726	ampicillin
+beta-lactam	blaGOB-1_1	EF394442	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-1_2	AF090141	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-10_1	AY647247	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-11_1	AY647248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-12_1	AY647249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-13_1	AY647251	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-14_1	AY647252	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-15_1	AY775547	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-16_1	GU188443	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-16_2	AY899331	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-17_1	AY899332	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-18_1	DQ004496	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-2_1	AF189296	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-3_1	AF189291	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-4_1	AF189293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-5_1	AF189290	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-6_1	AF189292	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-7_1	AF189297	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-8_1	AY348327	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaGOB-9_1	AY647246	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaHERA-1_1	AF311385	ampicillin
+beta-lactam	blaHERA-2_1	AF398334	ampicillin
+beta-lactam	blaHERA-3_1	AF398335	ampicillin
+beta-lactam	blaHERA-4_1	AJ536088	ampicillin
+beta-lactam	blaHERA-5_1	AJ536089	ampicillin
+beta-lactam	blaHERA-6_1	AJ536090	ampicillin
+beta-lactam	blaHERA-8_1	AJ536092	ampicillin
+beta-lactam	blaIMI-1_1	U50278	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMI-2_1	DQ173429	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMI-3_1	GU015024	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMI-5_1	KT599915	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-1_1	EF027105	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-10_1	AB074435	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-11_1	AB074436	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-12_1	AJ420864	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-13_1	AJ550807	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-14_1	AY553332	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-15_1	AY553333	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-16_1	AJ584652	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-17_1	AJ512502	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-18_1	AY780674	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-19_1	EF118171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-2_1	AJ243491	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-20_1	AB196988	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-21_1	AB204557	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-22_2	DQ361087	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-23_1	DQ417222	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-24_1	EF192154	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-25_1	EU541448	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-26_1	GU045307	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-27_1	JF894248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-28_1	JQ407409	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-29_1	HQ438058	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-3_1	AB010417	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-30_1	KM589497	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-31_1	KF148593	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-32_1	JQ002629	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-33_1	JN848782	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-34_1	AB715422	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-35_1	JF816544	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-37_1	JX131372	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-38_1	HQ875573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-4_1	AF244145	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-4_1	DQ307573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-40_1	AB753457	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-41_1	AB753458	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-42_1	AB753456	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-43_1	AB777500	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-44_1	AB777501	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-45_1	EU352796	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-48_1	KM087857	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-49_1	KP681694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-5_1	AF290912	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-51_1	LC031883	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-52_1	LC055762	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-53_1	HM106457	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-54_1	KU052795	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-55_1	KT935306	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-56_1	KU315553	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-58_1	KU647281	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-59_1	KX196782	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-6_1	AB753460	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-60_1	LC159227	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-61_1	KX462700	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-62_1	KX753224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
@@ -453,14 +881,44 @@ beta-lactam	blaIMP-64_1	KX949735	ampicillin,amoxicillin/clavulanic acid,cefoxiti
 beta-lactam	blaIMP-66_1	LC190726	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-67_1	MF281100	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-68_1	MF669572	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-7_1	AF318077	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-70_1	MG748725	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-71_1	MG818167	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-73_1	MH021848	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-74_1	MH243349	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaIMP-75_1	MH243350	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-8_1	DQ845788	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIMP-9_1	FJ655384	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-1_1	AF099139	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-10_1	GU206353	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-11_1	HM245379	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-12_1	HM245380	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-14_1	HM367709	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-15_1	AB563173	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-2_2	AF219127	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-2a_4	AF219130	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-2b_3	EF672681	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-2c_1	GU186042	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-3_1	AF219131	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-4_1	AF219135	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-5_1	AY504627	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-6_1	AM087455	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-7_1	AB529520	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-8_1	GU186044	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaIND-9_1	GU186045	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaJOHN-1_1	AY028464	ampicillin
+beta-lactam	blaKHM-1_1	AB364006	ampicillin
+beta-lactam	blaKPC-10_1	GQ140348	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-11_1	HM066995	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-12_1	HQ641422	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-13_1	HQ342889	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-14_1	JX524191	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-15_1	KC433553	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-16_1	KC465199	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-17_1	KC465200	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-18_1	KT884517	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-19_1	KJ775801	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-2_1	AY034847	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-21_1	LN609376	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-22_1	KM379100	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-23_1	MH450213	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
@@ -470,20 +928,153 @@ beta-lactam	blaKPC-26_1	KX619622	ampicillin,amoxicillin/clavulanic acid,cefoxiti
 beta-lactam	blaKPC-27_1	KX828722	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-28_1	KY282958	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-29_1	KY563764	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-3_1	HM769262	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-30_1	KY646302	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-31_1	MAPH01000113	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-32_1	MAPO01000050	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-33_1	CP025144	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-34_1	KU985429	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaKPC-35_1	MH404098	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-4_1	FJ473382	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-5_1	EU400222	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-6_1	EU555534	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-7_1	EU729727	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-8_1	FJ234412	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaKPC-9_1	FJ624872	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaL_1	NG050597	ampicillin
+beta-lactam	blaL_2	NG050596	ampicillin
+beta-lactam	blaL1_3	EF126059	ampicillin
+beta-lactam	blaLAP-1_1	EF026092	ampicillin
+beta-lactam	blaLAP-2_1	EU159120	ampicillin
+beta-lactam	blaLAT-1_1	X78117	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaLCR-1_1	X56809	ampicillin
+beta-lactam	blaLEN1_1	X04515	ampicillin
+beta-lactam	blaLEN10_1	AJ635419	ampicillin
+beta-lactam	blaLEN12_1	AJ635406	ampicillin
+beta-lactam	blaLEN13_1	AJ635403	ampicillin
+beta-lactam	blaLEN15_1	AF452105	ampicillin
+beta-lactam	blaLEN16_1	AY743416	ampicillin
+beta-lactam	blaLEN17_1	EF205593	ampicillin
+beta-lactam	blaLEN18_1	AM850908	ampicillin
+beta-lactam	blaLEN19_1	AM850909	ampicillin
+beta-lactam	blaLEN2_1	AY037780	ampicillin
+beta-lactam	blaLEN20_1	AM850910	ampicillin
+beta-lactam	blaLEN21_1	AM850911	ampicillin
+beta-lactam	blaLEN22_1	AM850912	ampicillin
+beta-lactam	blaLEN23_1	AM850913	ampicillin
+beta-lactam	blaLEN24_1	AM850914	ampicillin
+beta-lactam	blaLEN25_1	HQ709169	ampicillin
+beta-lactam	blaLEN26_1	JQ067123	ampicillin
+beta-lactam	blaLEN3_1	AY130286	ampicillin
+beta-lactam	blaLEN4_1	AY130287	ampicillin
+beta-lactam	blaLEN5_1	AY633109	ampicillin
+beta-lactam	blaLEN7_1	AJ635425	ampicillin
+beta-lactam	blaLEN8_1	AJ635424	ampicillin
+beta-lactam	blaLEN9_1	AJ635405	ampicillin
+beta-lactam	blaLUT-1_1	AY695112	ampicillin
+beta-lactam	blaMAL-1_1	AJ277209	ampicillin
+beta-lactam	blaMAL-1_2	AJ609506	ampicillin
+beta-lactam	blaMIR-1_1	M37839	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMIR-2_1	AY227752	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMIR-3_1	AY743435	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMIR-4_1	EF417572	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMIR-5_1	FJ237367	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMIR-6_1	JQ664733	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOR_1	Y10283	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOR-2_1	AY235804	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-1_1	D13304	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-2_1	AJ276453	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-3_1	EU515248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-4_1	FJ262599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-5_1	GQ152600	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-6_1	GQ152601	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMOX-7_1	GQ152602	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaMUS-1_1	AF441286	ampicillin
+beta-lactam	blaNDM-1_1	FN396876	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-10_1	KF361506	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-11_1	KP265939	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-12_1	AB926431	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-13_1	LC012596	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-14_1	KM210086	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-15_1	KP735848	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-16_1	KP862821	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-17_1	KX812714	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-18_1	KY503030	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-19_1	MF370080	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-2_1	JF703135	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-20_1	KY654092	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-21_1	MG183694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-22_1	MH243357	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-23_1	MH450214	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaNDM-24_1	MH450215	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-3_1	JQ734687	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-4_1	JQ348841	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-5_1	JN104597	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-6_1	JN967644	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-7_1	JX262694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-8_1	AB744718	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNDM-9_1	KC999080	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaNMC-A_1	AJ536087	ampicillin
+beta-lactam	blaNPS_1	AY027589	ampicillin
+beta-lactam	blaOCH-2_1	AJ295340	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-3_1	AJ295341	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-4_1	AJ295342	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-5_1	AJ295343	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-6_1	AJ295344	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-7_1	AJ295345	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOCH-8_1	DQ489307	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaOKP-A-1_1	AM051138	ampicillin
+beta-lactam	blaOKP-A-10_1	AM051149	ampicillin
+beta-lactam	blaOKP-A-11_1	AM850915	ampicillin
+beta-lactam	blaOKP-A-12_1	AM850915	ampicillin
+beta-lactam	blaOKP-A-13_1	FJ534513	ampicillin
+beta-lactam	blaOKP-A-14_1	FJ534512	ampicillin
+beta-lactam	blaOKP-A-15_1	FJ755841	ampicillin
+beta-lactam	blaOKP-A-16_1	FJ755840	ampicillin
+beta-lactam	blaOKP-A-2_1	AM051139	ampicillin
+beta-lactam	blaOKP-A-3_1	AM051140	ampicillin
+beta-lactam	blaOKP-A-4_1	AM051142	ampicillin
+beta-lactam	blaOKP-A-5_1	AM051143	ampicillin
+beta-lactam	blaOKP-A-6_1	AM051144	ampicillin
+beta-lactam	blaOKP-A-7_1	AM051145	ampicillin
+beta-lactam	blaOKP-A-8_1	AM051147	ampicillin
+beta-lactam	blaOKP-A-9_1	AM051148	ampicillin
+beta-lactam	blaOKP-B-1_1	AM051150	ampicillin
+beta-lactam	blaOKP-B-10_1	AM051160	ampicillin
+beta-lactam	blaOKP-B-11_1	AM051161	ampicillin
+beta-lactam	blaOKP-B-12_1	AJ635420	ampicillin
+beta-lactam	blaOKP-B-13_1	AY825330	ampicillin
+beta-lactam	blaOKP-B-14_1	DQ995288	ampicillin
+beta-lactam	blaOKP-B-15_1	AM850917	ampicillin
+beta-lactam	blaOKP-B-16_1	AM850918	ampicillin
+beta-lactam	blaOKP-B-17_1	AM850919	ampicillin
+beta-lactam	blaOKP-B-18_1	AM850920	ampicillin
+beta-lactam	blaOKP-B-19_1	AM850921	ampicillin
+beta-lactam	blaOKP-B-2_1	AM051151	ampicillin
+beta-lactam	blaOKP-B-20_1	AM850922	ampicillin
+beta-lactam	blaOKP-B-3_1	AM051152	ampicillin
+beta-lactam	blaOKP-B-4_1	AM051153	ampicillin
+beta-lactam	blaOKP-B-5_1	AY512506	ampicillin
+beta-lactam	blaOKP-B-6_1	AY850171	ampicillin
+beta-lactam	blaOKP-B-7_1	AM051156	ampicillin
+beta-lactam	blaOKP-B-8_1	AM051157	ampicillin
+beta-lactam	blaOKP-B-9_1	AM051159	ampicillin
+beta-lactam	blaOXA-1_1	HQ170510	ampicillin
+beta-lactam	blaOXA-10_1	J03427	ampicillin
+beta-lactam	blaOXA-100_1	AM231720	ampicillin
+beta-lactam	blaOXA-101_1	AM412777	ampicillin
 beta-lactam	blaOXA-102_1	NZ_LWGP01000001	ampicillin
 beta-lactam	blaOXA-103_1	APQF01000011	ampicillin
+beta-lactam	blaOXA-104_1	EF581285	ampicillin
+beta-lactam	blaOXA-106_1	EF650032	ampicillin
+beta-lactam	blaOXA-107_1	LAVJ01000082	ampicillin
+beta-lactam	blaOXA-108_1	EF650034	ampicillin
+beta-lactam	blaOXA-109_1	EF650035	ampicillin
+beta-lactam	blaOXA-11_1	Z22590	ampicillin,ceftriaxone
+beta-lactam	blaOXA-110_1	EF650036	ampicillin
+beta-lactam	blaOXA-111_1	EF650037	ampicillin
+beta-lactam	blaOXA-112_1	EF650038	ampicillin
+beta-lactam	blaOXA-113_1	EF653400	ampicillin
 beta-lactam	blaOXA-114a_1	EU188842	ampicillin
 beta-lactam	blaOXA-114b_1	HM056040	ampicillin
 beta-lactam	blaOXA-114c_1	HM056041	ampicillin
@@ -491,6 +1082,12 @@ beta-lactam	blaOXA-114d_1	HM104633	ampicillin
 beta-lactam	blaOXA-114e_1	HM104634	ampicillin
 beta-lactam	blaOXA-114f_1	HM368375	ampicillin
 beta-lactam	blaOXA-114g_1	HM368376	ampicillin
+beta-lactam	blaOXA-115_1	EU029998	ampicillin
+beta-lactam	blaOXA-116_1	EU220744	ampicillin
+beta-lactam	blaOXA-117_1	GQ423625	ampicillin
+beta-lactam	blaOXA-118_1	AF371964	ampicillin
+beta-lactam	blaOXA-119_1	DQ767903	ampicillin
+beta-lactam	blaOXA-120_1	EU255289	ampicillin
 beta-lactam	blaOXA-121_1	EU255290	ampicillin
 beta-lactam	blaOXA-122_1	EU255291	ampicillin
 beta-lactam	blaOXA-123_1	EU255292	ampicillin
@@ -498,52 +1095,223 @@ beta-lactam	blaOXA-124_1	EU255293	ampicillin
 beta-lactam	blaOXA-125_1	EU255294	ampicillin
 beta-lactam	blaOXA-126_1	EU255295	ampicillin
 beta-lactam	blaOXA-127_1	EU255296	ampicillin
+beta-lactam	blaOXA-128_1	EU375515	ampicillin
+beta-lactam	blaOXA-129_1	FJWZ01000025	ampicillin
+beta-lactam	blaOXA-13_1	AF043558	ampicillin
+beta-lactam	blaOXA-13_1	U59183	ampicillin
+beta-lactam	blaOXA-130_1	EU547445	ampicillin
+beta-lactam	blaOXA-131_1	EU547446	ampicillin
+beta-lactam	blaOXA-132_1	EU547447	ampicillin
+beta-lactam	blaOXA-133_1	EU571228	ampicillin
+beta-lactam	blaOXA-134_1	HQ122933	ampicillin
+beta-lactam	blaOXA-136_1	EU086831	ampicillin
+beta-lactam	blaOXA-137_1	EU086834	ampicillin
+beta-lactam	blaOXA-138_1	EU670845	ampicillin
+beta-lactam	blaOXA-139_1	AM991978	ampicillin
+beta-lactam	blaOXA-14_1	KJ420612	ampicillin,ceftriaxone
+beta-lactam	blaOXA-141_1	EF552405	ampicillin,ceftriaxone
+beta-lactam	blaOXA-142_1	LC169567	ampicillin,ceftriaxone
+beta-lactam	blaOXA-143_1	GQ861437	ampicillin
+beta-lactam	blaOXA-144_1	FJ872530	ampicillin
+beta-lactam	blaOXA-145_1	FJ790516	ampicillin,ceftriaxone
+beta-lactam	blaOXA-146_1	FJ194494	ampicillin
+beta-lactam	blaOXA-147_1	FJ848783	ampicillin,ceftriaxone
+beta-lactam	blaOXA-148_1	GQ853679	ampicillin
+beta-lactam	blaOXA-149_1	GQ853680	ampicillin
+beta-lactam	blaOXA-15_1	U63835	ampicillin,ceftriaxone
+beta-lactam	blaOXA-150_1	GQ853681	ampicillin
+beta-lactam	blaOXA-151_1	CP009553	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-152_1	KP771980	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-153_1	KP771981	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-154_1	KP771982	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-155_1	KP771983	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-156_1	KP771984	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-157_1	KP771985	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-158_1	KP771986	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-159_1	KP771987	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-16_1	AF043100	ampicillin,ceftriaxone
+beta-lactam	blaOXA-160_1	GU199038	ampicillin
+beta-lactam	blaOXA-161_1	GQ202693	ampicillin,ceftriaxone
+beta-lactam	blaOXA-162_1	GU197550	ampicillin
+beta-lactam	blaOXA-163_1	HQ700343	ampicillin
+beta-lactam	blaOXA-164_1	GU831575	ampicillin
+beta-lactam	blaOXA-165_1	HM488986	ampicillin
+beta-lactam	blaOXA-166_1	HM488987	ampicillin
+beta-lactam	blaOXA-167_1	HM488988	ampicillin
+beta-lactam	blaOXA-168_1	HM488989	ampicillin
+beta-lactam	blaOXA-169_1	HM488990	ampicillin
 beta-lactam	blaOXA-17_1	DQ902344	ampicillin
+beta-lactam	blaOXA-170_1	HM488991	ampicillin
+beta-lactam	blaOXA-171_1	HM488992	ampicillin
+beta-lactam	blaOXA-172_1	HM113558	ampicillin
+beta-lactam	blaOXA-173_1	HM113559	ampicillin
+beta-lactam	blaOXA-174_1	HM113560	ampicillin
+beta-lactam	blaOXA-175_1	HM113561	ampicillin
+beta-lactam	blaOXA-176_1	HM113562	ampicillin
+beta-lactam	blaOXA-177_1	HM113563	ampicillin
+beta-lactam	blaOXA-178_1	HM113564	ampicillin
+beta-lactam	blaOXA-179_1	HM570035	ampicillin
+beta-lactam	blaOXA-18_1	U85514	ampicillin
+beta-lactam	blaOXA-180_1	HM570036	ampicillin
+beta-lactam	blaOXA-181_1	CM004561	ampicillin
+beta-lactam	blaOXA-182_1	HM640278	ampicillin
+beta-lactam	blaOXA-183_1	HQ111474	ampicillin
+beta-lactam	blaOXA-184_1	JQ396378	ampicillin
+beta-lactam	blaOXA-185_1	JQ396379	ampicillin
+beta-lactam	blaOXA-19_1	AF043381	ampicillin,ceftriaxone
+beta-lactam	blaOXA-192_1	JF273470	ampicillin
 beta-lactam	blaOXA-193_1	CP013032	ampicillin
+beta-lactam	blaOXA-194_1	HQ425492	ampicillin
+beta-lactam	blaOXA-195_1	HQ425493	ampicillin
+beta-lactam	blaOXA-196_1	HQ425494	ampicillin
+beta-lactam	blaOXA-197_1	HQ425495	ampicillin
+beta-lactam	blaOXA-198_1	HQ634775	ampicillin
+beta-lactam	blaOXA-199_1	JN704570	ampicillin
+beta-lactam	blaOXA-2_1	DQ112222	ampicillin
+beta-lactam	blaOXA-2_2	GQ466184	ampicillin
+beta-lactam	blaOXA-20_1	AY307114	ampicillin
+beta-lactam	blaOXA-200_1	HQ734811	ampicillin
+beta-lactam	blaOXA-201_1	HQ734812	ampicillin
+beta-lactam	blaOXA-202_1	HQ734813	ampicillin
+beta-lactam	blaOXA-203_1	HQ998857	ampicillin
+beta-lactam	blaOXA-204_1	KP027885	ampicillin
+beta-lactam	blaOXA-205_1	JF800667	ampicillin
+beta-lactam	blaOXA-206_1	AB634250	ampicillin
+beta-lactam	blaOXA-207_1	LLFS01000355	ampicillin
+beta-lactam	blaOXA-208_1	KF305665	ampicillin
+beta-lactam	blaOXA-209_1	JF268688	ampicillin
 beta-lactam	blaOXA-21_1	AB626885	ampicillin
+beta-lactam	blaOXA-210_1	JF795487	ampicillin
+beta-lactam	blaOXA-211_1	JN861779	ampicillin
+beta-lactam	blaOXA-212_1	JN861780	ampicillin
+beta-lactam	blaOXA-213_1	JN861781	ampicillin
+beta-lactam	blaOXA-214_1	JN861782	ampicillin
+beta-lactam	blaOXA-215_1	JN861783	ampicillin
+beta-lactam	blaOXA-216_1	FR865168	ampicillin
+beta-lactam	blaOXA-217_1	JN603240	ampicillin
+beta-lactam	blaOXA-219_1	JN215211	ampicillin
+beta-lactam	blaOXA-22_1	AF064820	ampicillin
+beta-lactam	blaOXA-223_1	JN248564	ampicillin
+beta-lactam	blaOXA-224_1	JN412067	ampicillin
+beta-lactam	blaOXA-225_1	JN638887	ampicillin
 beta-lactam	blaOXA-226_1	FJ617207	ampicillin
+beta-lactam	blaOXA-228_1	JQ422053	ampicillin
+beta-lactam	blaOXA-229_1	JQ422052	ampicillin
+beta-lactam	blaOXA-23_1	AY795964	ampicillin,meropenem
+beta-lactam	blaOXA-230_1	JQ422054	ampicillin
+beta-lactam	blaOXA-231_1	JQ326200	ampicillin
+beta-lactam	blaOXA-232_1	JX423831	ampicillin
 beta-lactam	blaOXA-233_1	KJ657570	ampicillin
 beta-lactam	blaOXA-234_1	NG_050607	ampicillin
+beta-lactam	blaOXA-235_1	JQ820240	ampicillin
+beta-lactam	blaOXA-236_1	JQ820242	ampicillin
+beta-lactam	blaOXA-237_1	JQ820241	ampicillin
+beta-lactam	blaOXA-239_1	JQ837239	ampicillin
+beta-lactam	blaOXA-24_1	AJ239129	ampicillin,meropenem
+beta-lactam	blaOXA-240_1	JX089628	ampicillin
+beta-lactam	blaOXA-241_1	JX025021	ampicillin
+beta-lactam	blaOXA-242_1	JX025022	ampicillin
+beta-lactam	blaOXA-243_1	AFRQ01000031	ampicillin
+beta-lactam	blaOXA-244_1	KP659189	ampicillin,amoxicillin/clavulanic acid,ds-meropenem
+beta-lactam	blaOXA-245_1	JX438001	ampicillin
 beta-lactam	blaOXA-246_1	EU886980	ampicillin
+beta-lactam	blaOXA-247_1	JX893517	ampicillin
+beta-lactam	blaOXA-248_1	HE963769	ampicillin
+beta-lactam	blaOXA-249_1	HE963770	ampicillin
+beta-lactam	blaOXA-25_1	AF201826	ampicillin
+beta-lactam	blaOXA-250_1	HE963771	ampicillin
+beta-lactam	blaOXA-251_1	JN118546	ampicillin
 beta-lactam	blaOXA-252_1	NG_050608	ampicillin
+beta-lactam	blaOXA-253_1	KC479324	ampicillin
+beta-lactam	blaOXA-254_1	AB781687	ampicillin
+beta-lactam	blaOXA-255_1	KC479325	ampicillin
+beta-lactam	blaOXA-256_1	HE616889	ampicillin
+beta-lactam	blaOXA-257_1	KC567681	ampicillin
+beta-lactam	blaOXA-258_1	HE614014	ampicillin
 beta-lactam	blaOXA-259_1	KF057028	ampicillin
+beta-lactam	blaOXA-26_1	AF201827	ampicillin
 beta-lactam	blaOXA-260_1	APOR01000009	ampicillin
 beta-lactam	blaOXA-261_1	APQV01000009	ampicillin
 beta-lactam	blaOXA-262_1	APRA01000005	ampicillin
 beta-lactam	blaOXA-263_1	APQY01000006	ampicillin
 beta-lactam	blaOXA-264_1	APQQ01000012	ampicillin
 beta-lactam	blaOXA-265_1	APQR01000003	ampicillin
+beta-lactam	blaOXA-266_1	APPO01000008	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaOXA-267_1	APQH01000006	ampicillin
 beta-lactam	blaOXA-268_1	APOE01000008	ampicillin
 beta-lactam	blaOXA-269_1	APQJ01000007	ampicillin
+beta-lactam	blaOXA-27_1	AF201828	ampicillin
 beta-lactam	blaOXA-270_1	APQM01000006	ampicillin
 beta-lactam	blaOXA-271_1	APQO01000006	ampicillin
 beta-lactam	blaOXA-272_1	LSAL01000001	ampicillin
 beta-lactam	blaOXA-273_1	APQN01000012	ampicillin
+beta-lactam	blaOXA-274_1	APOS01000038	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-275_1	APPJ01000001	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaOXA-276_1	APPI01000013	ampicillin
 beta-lactam	blaOXA-277_1	APPQ01000011	ampicillin
+beta-lactam	blaOXA-278_1	KC771279	ampicillin
+beta-lactam	blaOXA-279_1	APOM01000058	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-28_1	AF231133	ampicillin,ceftriaxone
 beta-lactam	blaOXA-280_1	APPZ01000001	ampicillin
 beta-lactam	blaOXA-281_1	APON01000041	ampicillin
 beta-lactam	blaOXA-282_1	APQS01000019	ampicillin
 beta-lactam	blaOXA-283_1	AYHO01000005	ampicillin
 beta-lactam	blaOXA-284_1	APRU01000004	ampicillin
 beta-lactam	blaOXA-285_1	APRY01000059	ampicillin
+beta-lactam	blaOXA-286_1	APOI01000030	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-287_1	NG_050609	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaOXA-288_1	APRN01000033	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaOXA-289_1	APRM01000005	ampicillin
+beta-lactam	blaOXA-29_1	AJ400619	ampicillin
 beta-lactam	blaOXA-290_1	APOK01000044	ampicillin
+beta-lactam	blaOXA-291_1	APRL01000010	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-292_1	APRO01000007	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-293_1	NG_050610	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaOXA-294_1	APPC01000015	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-295_1	APRW01000016	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-296_1	APOH01000009	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-297_1	APRR01000006	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaOXA-298_1	APSA01000003	ampicillin
+beta-lactam	blaOXA-299_1	APQD01000016	ampicillin
+beta-lactam	blaOXA-3_1	L07945	ampicillin
 beta-lactam	blaOXA-300_1	APPK01000054	ampicillin
 beta-lactam	blaOXA-301_1	APQG01000050	ampicillin
+beta-lactam	blaOXA-302_1	APRT01000004	ampicillin
+beta-lactam	blaOXA-303_1	APSD01000035	ampicillin
 beta-lactam	blaOXA-304_1	APSC01000007	ampicillin
 beta-lactam	blaOXA-305_1	APPF01000021	ampicillin
+beta-lactam	blaOXA-306_1	APSB01000022	ampicillin
+beta-lactam	blaOXA-307_1	NG_050611	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaOXA-308_1	APPN01000080	ampicillin
+beta-lactam	blaOXA-309_1	HF947514	ampicillin
+beta-lactam	blaOXA-31_1	AF294653	ampicillin
 beta-lactam	blaOXA-312_1	KF057029	ampicillin
 beta-lactam	blaOXA-313_1	KF057030	ampicillin
 beta-lactam	blaOXA-314_1	KF057031	ampicillin
 beta-lactam	blaOXA-315_1	KF057032	ampicillin
 beta-lactam	blaOXA-316_1	KF057033	ampicillin
 beta-lactam	blaOXA-317_1	KF057034	ampicillin
+beta-lactam	blaOXA-32_1	AF315351	ampicillin,ceftriaxone
+beta-lactam	blaOXA-320_1	KF151169	ampicillin
+beta-lactam	blaOXA-322_1	KF203096	ampicillin
+beta-lactam	blaOXA-323_1	KF203097	ampicillin
+beta-lactam	blaOXA-324_1	KF203098	ampicillin
+beta-lactam	blaOXA-325_1	KF203099	ampicillin
+beta-lactam	blaOXA-326_1	KF203100	ampicillin
+beta-lactam	blaOXA-327_1	KF203101	ampicillin
+beta-lactam	blaOXA-328_1	KF203102	ampicillin
+beta-lactam	blaOXA-329_1	KF203103	ampicillin
+beta-lactam	blaOXA-330_1	KF203104	ampicillin
+beta-lactam	blaOXA-331_1	KF203105	ampicillin
+beta-lactam	blaOXA-332_1	KF203106	ampicillin
+beta-lactam	blaOXA-333_1	KF203107	ampicillin
+beta-lactam	blaOXA-334_1	KF203108	ampicillin
+beta-lactam	blaOXA-335_1	KF203109	ampicillin
 beta-lactam	blaOXA-336_1	KF048907	ampicillin
 beta-lactam	blaOXA-337_1	KF048908	ampicillin
 beta-lactam	blaOXA-338_1	KF048909	ampicillin
 beta-lactam	blaOXA-339_1	KF048911	ampicillin
+beta-lactam	blaOXA-34_1	AF350424	ampicillin
 beta-lactam	blaOXA-340_1	KF048912	ampicillin
 beta-lactam	blaOXA-341_1	KF048913	ampicillin
 beta-lactam	blaOXA-342_1	KF048915	ampicillin
@@ -551,6 +1319,23 @@ beta-lactam	blaOXA-343_1	KF048916	ampicillin
 beta-lactam	blaOXA-344_1	KF048917	ampicillin
 beta-lactam	blaOXA-345_1	KF048918	ampicillin
 beta-lactam	blaOXA-346_1	KF048919	ampicillin
+beta-lactam	blaOXA-347_1	ACWG01000053	ampicillin
+beta-lactam	blaOXA-347_1	JN086160	ampicillin
+beta-lactam	blaOXA-348_1	KF297577	ampicillin
+beta-lactam	blaOXA-349_1	KF297578	ampicillin
+beta-lactam	blaOXA-35_1	AF315786	ampicillin,ceftriaxone
+beta-lactam	blaOXA-350_1	KF297579	ampicillin
+beta-lactam	blaOXA-351_1	KF297580	ampicillin
+beta-lactam	blaOXA-352_1	KF297581	ampicillin
+beta-lactam	blaOXA-353_1	KF297582	ampicillin
+beta-lactam	blaOXA-354_1	KF297583	ampicillin
+beta-lactam	blaOXA-355_1	KF297584	ampicillin
+beta-lactam	blaOXA-356_1	KF297585	ampicillin
+beta-lactam	blaOXA-357_1	KF421160	ampicillin
+beta-lactam	blaOXA-358_1	KF421161	ampicillin
+beta-lactam	blaOXA-359_1	KF421162	ampicillin
+beta-lactam	blaOXA-36_1	AF300985	ampicillin,ceftriaxone
+beta-lactam	blaOXA-360_1	KF421163	ampicillin
 beta-lactam	blaOXA-361_1	KF460531	ampicillin
 beta-lactam	blaOXA-362_1	KF460532	ampicillin
 beta-lactam	blaOXA-363_1	KF460533	ampicillin
@@ -558,7 +1343,10 @@ beta-lactam	blaOXA-364_1	JX306689	ampicillin
 beta-lactam	blaOXA-365_1	KF885217	ampicillin
 beta-lactam	blaOXA-366_1	KP050485	ampicillin
 beta-lactam	blaOXA-368_1	KT736121	ampicillin
+beta-lactam	blaOXA-37_1	AY007784	ampicillin,ceftriaxone
 beta-lactam	blaOXA-370_1	KJ488943	ampicillin
+beta-lactam	blaOXA-371_1	AB871653	ampicillin
+beta-lactam	blaOXA-372_1	KJ746496	ampicillin
 beta-lactam	blaOXA-373_1	HG931732	ampicillin
 beta-lactam	blaOXA-374_1	KF986255	ampicillin
 beta-lactam	blaOXA-375_1	KF986256	ampicillin
@@ -583,6 +1371,7 @@ beta-lactam	blaOXA-395_1	AY306133	ampicillin
 beta-lactam	blaOXA-396_1	AY306134	ampicillin
 beta-lactam	blaOXA-397_1	KM087865	ampicillin
 beta-lactam	blaOXA-398_1	KM087842	ampicillin
+beta-lactam	blaOXA-4_1	AY162283	ampicillin
 beta-lactam	blaOXA-400_1	KJ780078	ampicillin
 beta-lactam	blaOXA-401_1	KJ780076	ampicillin
 beta-lactam	blaOXA-402_1	JX865391	ampicillin
@@ -602,6 +1391,7 @@ beta-lactam	blaOXA-415_1	KJ865754	ampicillin
 beta-lactam	blaOXA-416_1	KP264119	ampicillin
 beta-lactam	blaOXA-417_1	KM220587	ampicillin
 beta-lactam	blaOXA-418_1	KJ997966	ampicillin
+beta-lactam	blaOXA-42_1	AJ488302	ampicillin
 beta-lactam	blaOXA-420_1	AB983359	ampicillin
 beta-lactam	blaOXA-421_1	KM401566	ampicillin
 beta-lactam	blaOXA-422_1	KM433671	ampicillin
@@ -609,12 +1399,15 @@ beta-lactam	blaOXA-423_1	KM433672	ampicillin
 beta-lactam	blaOXA-424_1	KM588352	ampicillin
 beta-lactam	blaOXA-425_1	KM588353	ampicillin
 beta-lactam	blaOXA-426_1	KM588354	ampicillin
+beta-lactam	blaOXA-427_1	KX827604	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaOXA-429_1	KM979376	ampicillin
+beta-lactam	blaOXA-43_1	AJ488303	ampicillin
 beta-lactam	blaOXA-430_1	KM979377	ampicillin
 beta-lactam	blaOXA-431_1	KM979378	ampicillin
 beta-lactam	blaOXA-432_1	KM979379	ampicillin
 beta-lactam	blaOXA-433_1	KM979380	ampicillin
 beta-lactam	blaOXA-435_1	KP144324	ampicillin
+beta-lactam	blaOXA-436_1	KT959105	ampicillin
 beta-lactam	blaOXA-437_1	KP410856	ampicillin
 beta-lactam	blaOXA-438_1	KP410734	ampicillin
 beta-lactam	blaOXA-439_1	KP727573	ampicillin
@@ -623,6 +1416,11 @@ beta-lactam	blaOXA-441_1	JX865394	ampicillin
 beta-lactam	blaOXA-442_1	KP844571	ampicillin
 beta-lactam	blaOXA-443_1	LC030178	ampicillin
 beta-lactam	blaOXA-444_1	CP010800	ampicillin
+beta-lactam	blaOXA-446_1	KR061495	ampicillin
+beta-lactam	blaOXA-447_1	KR061496	ampicillin
+beta-lactam	blaOXA-448_1	KR061497	ampicillin
+beta-lactam	blaOXA-449_1	KR061498	ampicillin
+beta-lactam	blaOXA-45_1	AJ519683	ampicillin
 beta-lactam	blaOXA-450_1	KR061502	ampicillin
 beta-lactam	blaOXA-451_1	KR061504	ampicillin
 beta-lactam	blaOXA-452_1	KR061505	ampicillin
@@ -632,8 +1430,13 @@ beta-lactam	blaOXA-455_1	KP903885	ampicillin
 beta-lactam	blaOXA-457_1	KP903887	ampicillin
 beta-lactam	blaOXA-458_1	KP903888	ampicillin
 beta-lactam	blaOXA-459_1	KP903889	ampicillin
+beta-lactam	blaOXA-46_1	AF317511	ampicillin
 beta-lactam	blaOXA-460_1	KR061508	ampicillin
 beta-lactam	blaOXA-461_1	KR061509	ampicillin
+beta-lactam	blaOXA-464_1	KU721146	ampicillin
+beta-lactam	blaOXA-465_1	KR061500	ampicillin
+beta-lactam	blaOXA-466_1	KR061501	ampicillin
+beta-lactam	blaOXA-47_1	AY237830	ampicillin
 beta-lactam	blaOXA-470_1	KR182163	ampicillin
 beta-lactam	blaOXA-471_1	EU086833	ampicillin
 beta-lactam	blaOXA-472_1	KR182165	ampicillin
@@ -644,6 +1447,7 @@ beta-lactam	blaOXA-476_1	KR182169	ampicillin
 beta-lactam	blaOXA-477_1	KR182170	ampicillin
 beta-lactam	blaOXA-478_1	KR182171	ampicillin
 beta-lactam	blaOXA-479_1	KR182172	ampicillin
+beta-lactam	blaOXA-48_1	AY236073	ampicillin,amoxicillin/clavulanic acid,decreased susceptibility to meropenem
 beta-lactam	blaOXA-480_1	KR872296	ampicillin
 beta-lactam	blaOXA-482_1	KP264124	ampicillin
 beta-lactam	blaOXA-483_1	KP264125	ampicillin
@@ -652,11 +1456,17 @@ beta-lactam	blaOXA-485_1	LLNM01000004	ampicillin
 beta-lactam	blaOXA-486_1	AY597426	ampicillin
 beta-lactam	blaOXA-488_1	CP017969	ampicillin
 beta-lactam	blaOXA-489_1	CP013733	ampicillin
+beta-lactam	blaOXA-49_1	AY288523	ampicillin
 beta-lactam	blaOXA-490_1	KU721147	ampicillin
+beta-lactam	blaOXA-491_1	KU721148	ampicillin
+beta-lactam	blaOXA-493_1	CP007774	ampicillin
+beta-lactam	blaOXA-493_1	KU739135	ampicillin
 beta-lactam	blaOXA-494_1	AY597430	ampicillin
 beta-lactam	blaOXA-496_1	KT200608	ampicillin
 beta-lactam	blaOXA-497_1	LKJZ01000136	ampicillin
 beta-lactam	blaOXA-499_1	KT964029	ampicillin
+beta-lactam	blaOXA-5_1	AF347074	ampicillin
+beta-lactam	blaOXA-50_1	AY306130	ampicillin
 beta-lactam	blaOXA-500_1	JMNQ01000002	ampicillin
 beta-lactam	blaOXA-501_1	KU167110	ampicillin
 beta-lactam	blaOXA-502_1	KU167111	ampicillin
@@ -666,6 +1476,7 @@ beta-lactam	blaOXA-506_1	KU571454	ampicillin
 beta-lactam	blaOXA-507_1	KU551305	ampicillin
 beta-lactam	blaOXA-508_1	KU596972	ampicillin
 beta-lactam	blaOXA-509_1	KU692025	ampicillin
+beta-lactam	blaOXA-51_1	DQ385606	ampicillin,meropenem
 beta-lactam	blaOXA-510_1	JX865393	ampicillin
 beta-lactam	blaOXA-511_1	KU710720	ampicillin
 beta-lactam	blaOXA-512_1	KU726870	ampicillin
@@ -674,6 +1485,7 @@ beta-lactam	blaOXA-514_1	KU866382	ampicillin
 beta-lactam	blaOXA-515_1	KU866383	ampicillin
 beta-lactam	blaOXA-516_1	KU871391	ampicillin
 beta-lactam	blaOXA-517_1	KU878974	ampicillin
+beta-lactam	blaOXA-518_1	KU739134	ampicillin
 beta-lactam	blaOXA-519_1	KX349732	ampicillin
 beta-lactam	blaOXA-520_1	KX388630	ampicillin
 beta-lactam	blaOXA-521_1	KX462701	ampicillin
@@ -685,6 +1497,7 @@ beta-lactam	blaOXA-526_1	KX599409	ampicillin
 beta-lactam	blaOXA-527_1	KX599404	ampicillin
 beta-lactam	blaOXA-528_1	KX599407	ampicillin
 beta-lactam	blaOXA-529_1	KX599405	ampicillin
+beta-lactam	blaOXA-53_1	AY289608	ampicillin
 beta-lactam	blaOXA-530_1	KX599398	ampicillin
 beta-lactam	blaOXA-531_1	KX599400	ampicillin
 beta-lactam	blaOXA-532_1	KX609247	ampicillin
@@ -695,6 +1508,7 @@ beta-lactam	blaOXA-536_1	KX859240	ampicillin
 beta-lactam	blaOXA-537_1	KX360747	ampicillin
 beta-lactam	blaOXA-538_1	KX827284	ampicillin
 beta-lactam	blaOXA-539_1	KY094077	ampicillin
+beta-lactam	blaOXA-54_1	AY500137	ampicillin
 beta-lactam	blaOXA-540_1	KJ138219	ampicillin
 beta-lactam	blaOXA-541_1	FM179467	ampicillin
 beta-lactam	blaOXA-545_1	KY674541	ampicillin
@@ -702,6 +1516,7 @@ beta-lactam	blaOXA-546_1	KY682756	ampicillin
 beta-lactam	blaOXA-547_1	KY684124	ampicillin
 beta-lactam	blaOXA-548_1	KY682750	ampicillin
 beta-lactam	blaOXA-549_1	KY682751	ampicillin
+beta-lactam	blaOXA-55_1	AY343493	ampicillin
 beta-lactam	blaOXA-550_1	KY682752	ampicillin
 beta-lactam	blaOXA-551_1	KY682753	ampicillin
 beta-lactam	blaOXA-552_1	KY682754	ampicillin
@@ -712,6 +1527,7 @@ beta-lactam	blaOXA-556_1	KY126231	ampicillin
 beta-lactam	blaOXA-557_1	KY126232	ampicillin
 beta-lactam	blaOXA-558_1	KY126234	ampicillin
 beta-lactam	blaOXA-559_1	KY126237	ampicillin
+beta-lactam	blaOXA-56_1	AY445080	ampicillin
 beta-lactam	blaOXA-560_1	KY126238	ampicillin
 beta-lactam	blaOXA-561_1	KY126240	ampicillin
 beta-lactam	blaOXA-562_1	KY126241	ampicillin
@@ -719,12 +1535,172 @@ beta-lactam	blaOXA-563_1	KY767021	ampicillin
 beta-lactam	blaOXA-564_1	KY767022	ampicillin
 beta-lactam	blaOXA-565_1	KY883665	ampicillin
 beta-lactam	blaOXA-566_1	MF099636	ampicillin
+beta-lactam	blaOXA-57_1	AJ631966	ampicillin
+beta-lactam	blaOXA-58_1	AY665723	ampicillin,meropenem
+beta-lactam	blaOXA-59_1	AJ632249	ampicillin
+beta-lactam	blaOXA-60_1	AF525303	ampicillin
+beta-lactam	blaOXA-61_1	AY587956	ampicillin
+beta-lactam	blaOXA-62_1	AY423074	ampicillin
+beta-lactam	blaOXA-63_1	AY619003	ampicillin
+beta-lactam	blaOXA-64_1	AY750907	ampicillin
+beta-lactam	blaOXA-65_1	AY750908	ampicillin
 beta-lactam	blaOXA-66_1	AY750909	ampicillin
+beta-lactam	blaOXA-67_1	DQ491200	ampicillin
+beta-lactam	blaOXA-68_1	AY750910	ampicillin
+beta-lactam	blaOXA-69_1	AY859527	ampicillin
+beta-lactam	blaOXA-7_1	X75562	ampicillin
+beta-lactam	blaOXA-70_1	AY750912	ampicillin
+beta-lactam	blaOXA-71_1	AY750913	ampicillin
+beta-lactam	blaOXA-72_1	AY739646	ampicillin
+beta-lactam	blaOXA-73_1	AY762325	ampicillin
+beta-lactam	blaOXA-74_1	EU161636	ampicillin
+beta-lactam	blaOXA-75_1	AY859529	ampicillin
+beta-lactam	blaOXA-76_1	AY949203	ampicillin
+beta-lactam	blaOXA-77_1	AY949202	ampicillin
+beta-lactam	blaOXA-78_1	AY862132	ampicillin
+beta-lactam	blaOXA-79_1	EU019534	ampicillin
+beta-lactam	blaOXA-80_1	EU019535	ampicillin
+beta-lactam	blaOXA-82_1	DQ987479	ampicillin
+beta-lactam	blaOXA-83_1	DQ309277	ampicillin
+beta-lactam	blaOXA-84_1	DQ309276	ampicillin
+beta-lactam	blaOXA-85_1	JANA01000064	ampicillin
+beta-lactam	blaOXA-86_1	DQ149247	ampicillin
+beta-lactam	blaOXA-87_1	DQ348075	ampicillin
+beta-lactam	blaOXA-88_1	DQ392963	ampicillin
 beta-lactam	blaOXA-89_1	DQ445683	ampicillin
 beta-lactam	blaOXA-9_1	KQ089875	ampicillin
+beta-lactam	blaOXA-90_1	EU547443	ampicillin
+beta-lactam	blaOXA-91_1	DQ519086	ampicillin
+beta-lactam	blaOXA-92_1	DQ335566	ampicillin
+beta-lactam	blaOXA-93_1	DQ519087	ampicillin
+beta-lactam	blaOXA-94_1	DQ519088	ampicillin
+beta-lactam	blaOXA-95_1	DQ519089	ampicillin
+beta-lactam	blaOXA-96_1	DQ519090	ampicillin
+beta-lactam	blaOXA-97_1	EF102240	ampicillin
+beta-lactam	blaOXA-98_1	EU255288	ampicillin
+beta-lactam	blaOXA-99_1	DQ888718	ampicillin
+beta-lactam	blaOXA-SHE_1	AY066004	ampicillin
+beta-lactam	blaOXY-1-1_1	Z30177	ampicillin
+beta-lactam	blaOXY-1-2_2	AJ871864	ampicillin
+beta-lactam	blaOXY-1-3_3	AY077482	ampicillin
+beta-lactam	blaOXY-1-4_4	AY077483	ampicillin
+beta-lactam	blaOXY-1-5_5	AY077486	ampicillin
+beta-lactam	blaOXY-1-6_6	Y17715	ampicillin
+beta-lactam	blaOXY-1-7_7	M27459	ampicillin
+beta-lactam	blaOXY-2-1_1	AJ871866	ampicillin
+beta-lactam	blaOXY-2-10_10	FJ785626	ampicillin
+beta-lactam	blaOXY-2-2_2	AJ871867	ampicillin
+beta-lactam	blaOXY-2-3_3	AY077488	ampicillin
+beta-lactam	blaOXY-2-4_4	Y17714	ampicillin
+beta-lactam	blaOXY-2-5_5	AY077487	ampicillin
+beta-lactam	blaOXY-2-6_6	AY077485	ampicillin
+beta-lactam	blaOXY-2-7_7	Z49084	ampicillin
+beta-lactam	blaOXY-2-8_8	AY055205	ampicillin
+beta-lactam	blaOXY-2-9_9	FJ785625	ampicillin
+beta-lactam	blaOXY-3-1_1	AF491278	ampicillin
+beta-lactam	blaOXY-4-1_1	AY077481	ampicillin
+beta-lactam	blaOXY-5-1_1	AJ871868	ampicillin
+beta-lactam	blaOXY-5-2_2	AJ871871	ampicillin
+beta-lactam	blaOXY-6-1_1	AJ871873	ampicillin
+beta-lactam	blaOXY-6-2_2	AJ871875	ampicillin
+beta-lactam	blaOXY-6-3_3	AJ871876	ampicillin
+beta-lactam	blaOXY-6-4_4	AJ871877	ampicillin
+beta-lactam	blaPAM-1_1	AB858498	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaPAO_1	AY083595	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaPAO_2	FJ666065	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaPAO_3	FJ666073	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaPAO_4	AY083592	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
+beta-lactam	blaPEDO-1_1	KP109677	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaPEDO-2_1	KP109678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaPEDO-3_1	KP109679	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaPER-1_1	GU944725	ampicillin,ceftriaxone
+beta-lactam	blaPER-2_1	X93314	ampicillin,ceftriaxone
+beta-lactam	blaPER-3_1	AY740681	ampicillin,ceftriaxone
+beta-lactam	blaPER-4_1	EU748544	ampicillin,ceftriaxone
+beta-lactam	blaPER-5_1	FJ627180	ampicillin,ceftriaxone
+beta-lactam	blaPER-6_1	GQ396303	ampicillin,ceftriaxone
+beta-lactam	blaPER-7_1	HQ713678	ampicillin,ceftriaxone
+beta-lactam	blaPLA1a_1	AY302757	ampicillin
+beta-lactam	blaPLA2a_1	AY307385	ampicillin
+beta-lactam	blaPLA-3A_1	AY507663	ampicillin
+beta-lactam	blaPLA-4A_1	AY507664	ampicillin
+beta-lactam	blaPLA-5A_1	DQ249871	ampicillin
+beta-lactam	blaPLA-6A_1	DQ251478	ampicillin
+beta-lactam	blaPME-1_1	HQ541434	ampicillin
+beta-lactam	blaRAHN-1_1	GU645205	ampicillin,ceftriaxone
+beta-lactam	blaRAHN-1_2	AF338038	ampicillin,ceftriaxone
+beta-lactam	blaRAHN-2_2	HM114350	ampicillin,ceftriaxone
+beta-lactam	blaROB-1_1	DQ840517	ampicillin
+beta-lactam	blaROB-1_2	AF022114	ampicillin
+beta-lactam	blaSCO-1_1	EF063111	ampicillin
+beta-lactam	blaSED1_1	AF321608	ampicillin
+beta-lactam	blaSFC-1_1	AY354402	ampicillin,meropenem
+beta-lactam	blaSFO-1_1	AB003148	ampicillin
+beta-lactam	blaSGM-1_1	AAQG01000013	ampicillin
+beta-lactam	blaSGM-2_1	AP010803	ampicillin
+beta-lactam	blaSGM-4_1	CP002798	ampicillin
+beta-lactam	blaSGM-5_1	NG049987	ampicillin
+beta-lactam	blaSGM-6_1	NG049988	ampicillin
+beta-lactam	blaSGM-7_1	NG050614	ampicillin
+beta-lactam	blaSHV-1_1	AF148850	ampicillin
+beta-lactam	blaSHV-100_1	AM941846	ampicillin,ceftriaxone
+beta-lactam	blaSHV-101_1	EU155018	ampicillin
 beta-lactam	blaSHV-102_1	EU024485	ampicillin
+beta-lactam	blaSHV-103_1	EU032604	ampicillin
+beta-lactam	blaSHV-104_1	EU274581	ampicillin,ceftriaxone
+beta-lactam	blaSHV-105_1	FJ194944	ampicillin,ceftriaxone
+beta-lactam	blaSHV-106_1	AM922307	ampicillin
+beta-lactam	blaSHV-107_1	AM922308	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaSHV-108_1	AM922309	ampicillin
+beta-lactam	blaSHV-109_1	EU418913	ampicillin
+beta-lactam	blaSHV-11_1	X98101	ampicillin
+beta-lactam	blaSHV-110_1	HQ877615	ampicillin
 beta-lactam	blaSHV-111_1	AB372881	ampicillin
 beta-lactam	blaSHV-119_1	JX192924	ampicillin
+beta-lactam	blaSHV-12_1	KF976405	ampicillin,ceftriaxone
+beta-lactam	blaSHV-120_1	JF812965	ampicillin
+beta-lactam	blaSHV-121_1	GQ428198	ampicillin
+beta-lactam	blaSHV-128_1	GU932590	ampicillin
+beta-lactam	blaSHV-129_1	GU827715	ampicillin
+beta-lactam	blaSHV-13_1	AF164577	ampicillin,ceftriaxone
+beta-lactam	blaSHV-132_1	GU981741	ampicillin
+beta-lactam	blaSHV-133_1	AB551737	ampicillin
+beta-lactam	blaSHV-134_1	HM559945	ampicillin,ceftriaxone
+beta-lactam	blaSHV-135_1	HQ637576	ampicillin
+beta-lactam	blaSHV-137_1	HQ661363	ampicillin
+beta-lactam	blaSHV-14_1	AF226622	ampicillin
+beta-lactam	blaSHV-141_1	JQ388884	ampicillin
+beta-lactam	blaSHV-142_1	JQ029959	ampicillin
+beta-lactam	blaSHV-143_1	JQ341060	ampicillin
+beta-lactam	blaSHV-144_1	JQ926986	ampicillin
+beta-lactam	blaSHV-145_1	JX013655	ampicillin
+beta-lactam	blaSHV-147_1	JX121114	ampicillin
+beta-lactam	blaSHV-148_1	JX121115	ampicillin
+beta-lactam	blaSHV-149_1	JX121116	ampicillin
+beta-lactam	blaSHV-15_1	AJ011428	ampicillin,ceftriaxone
+beta-lactam	blaSHV-150_1	JX121117	ampicillin
+beta-lactam	blaSHV-151_1	JX121118	ampicillin
+beta-lactam	blaSHV-152_1	JX121119	ampicillin
+beta-lactam	blaSHV-153_1	JX121120	ampicillin
+beta-lactam	blaSHV-154_1	JX121121	ampicillin
+beta-lactam	blaSHV-155_1	JX121122	ampicillin
+beta-lactam	blaSHV-156_1	JX121123	ampicillin
+beta-lactam	blaSHV-157_1	JX121124	ampicillin
+beta-lactam	blaSHV-158_1	JX121125	ampicillin
+beta-lactam	blaSHV-159_1	JX121126	ampicillin
+beta-lactam	blaSHV-16_1	AF072684	ampicillin,ceftriaxone
+beta-lactam	blaSHV-160_1	JX121127	ampicillin
+beta-lactam	blaSHV-161_1	JX121128	ampicillin
+beta-lactam	blaSHV-162_1	JX121129	ampicillin
+beta-lactam	blaSHV-163_1	JX121130	ampicillin
+beta-lactam	blaSHV-164_1	HE981194	ampicillin
+beta-lactam	blaSHV-165_1	JX121131	ampicillin
+beta-lactam	blaSHV-168_1	JX870080	ampicillin
+beta-lactam	blaSHV-172_1	KF513177	ampicillin
+beta-lactam	blaSHV-173_1	KF513178	ampicillin
+beta-lactam	blaSHV-178_1	KF705209	ampicillin
+beta-lactam	blaSHV-179_1	KF705208	ampicillin
+beta-lactam	blaSHV-18_1	AF132290	ampicillin,ceftriaxone
 beta-lactam	blaSHV-180_1	KP050487	ampicillin
 beta-lactam	blaSHV-182_1	KP050489	ampicillin
 beta-lactam	blaSHV-183_1	HG934764	ampicillin
@@ -742,28 +1718,205 @@ beta-lactam	blaSHV-196_1	KX714286	ampicillin
 beta-lactam	blaSHV-197_1	KT946904	ampicillin
 beta-lactam	blaSHV-198_1	MF281086	ampicillin
 beta-lactam	blaSHV-199_1	MF373391	ampicillin
+beta-lactam	blaSHV-2_1	AF148851	ampicillin,ceftriaxone
 beta-lactam	blaSHV-200_1	MF871643	ampicillin
 beta-lactam	blaSHV-203_1	MG028656	ampicillin
 beta-lactam	blaSHV-204_1	MH243356	ampicillin
+beta-lactam	blaSHV-24_1	AB023477	ampicillin,ceftriaxone
+beta-lactam	blaSHV-25_1	AF208796	ampicillin
+beta-lactam	blaSHV-26_1	AF227204	ampicillin
+beta-lactam	blaSHV-27_1	AF293345	ampicillin
+beta-lactam	blaSHV-28_1	AF299299	ampicillin
+beta-lactam	blaSHV-29_1	AF301532	ampicillin
+beta-lactam	blaSHV-2a_1	X98102	ampicillin,ceftriaxone
 beta-lactam	blaSHV-3_1	KX092356	ampicillin
+beta-lactam	blaSHV-30_1	AY661885	ampicillin,ceftriaxone
+beta-lactam	blaSHV-31_1	AY277255	ampicillin,ceftriaxone
 beta-lactam	blaSHV-32_1	AY037778	ampicillin
+beta-lactam	blaSHV-33_1	AY037779	ampicillin
+beta-lactam	blaSHV-34_1	AY036620	ampicillin
+beta-lactam	blaSHV-35_1	AY070258	ampicillin
+beta-lactam	blaSHV-36_1	AF467947	ampicillin
+beta-lactam	blaSHV-37_1	AF467948	ampicillin
+beta-lactam	blaSHV-38_1	AY079099	ampicillin,ceftriaxone
+beta-lactam	blaSHV-40_1	AF535128	ampicillin,ceftriaxone
+beta-lactam	blaSHV-41_1	AF535129	ampicillin,ceftriaxone
+beta-lactam	blaSHV-42_1	AF535130	ampicillin,ceftriaxone
+beta-lactam	blaSHV-43_1	AY065991	ampicillin
+beta-lactam	blaSHV-44_1	AY259119	ampicillin
+beta-lactam	blaSHV-45_1	AF547625	ampicillin,ceftriaxone
+beta-lactam	blaSHV-46_1	AY210887	ampicillin,ceftriaxone
+beta-lactam	blaSHV-48_1	AY263404	ampicillin
+beta-lactam	blaSHV-49_1	AY528718	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaSHV-5_1	X55640	ampicillin,ceftriaxone
+beta-lactam	blaSHV-50_1	AY288915	ampicillin
+beta-lactam	blaSHV-51_1	AY289548	ampicillin
+beta-lactam	blaSHV-52_1	HQ845196	ampicillin
+beta-lactam	blaSHV-55_1	DQ054528	ampicillin,ceftriaxone
+beta-lactam	blaSHV-56_1	EU586041	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaSHV-57_1	AY223863	ampicillin,ceftriaxone
+beta-lactam	blaSHV-59_1	AY790341	ampicillin
+beta-lactam	blaSHV-60_1	AB302939	ampicillin
+beta-lactam	blaSHV-61_1	AJ866284	ampicillin
+beta-lactam	blaSHV-62_1	AJ866285	ampicillin
+beta-lactam	blaSHV-63_1	EU342351	ampicillin
+beta-lactam	blaSHV-64_1	DQ174304	ampicillin,ceftriaxone
+beta-lactam	blaSHV-65_1	DQ174305	ampicillin
+beta-lactam	blaSHV-66_1	DQ174306	ampicillin,ceftriaxone
+beta-lactam	blaSHV-67_1	DQ174307	ampicillin
+beta-lactam	blaSHV-69_1	DQ174308	ampicillin
+beta-lactam	blaSHV-7_1	U20270	ampicillin,ceftriaxone
+beta-lactam	blaSHV-70_1	DQ013287	ampicillin,ceftriaxone
+beta-lactam	blaSHV-71_1	AM176546	ampicillin
+beta-lactam	blaSHV-72_1	AM176547	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaSHV-73_1	AM176548	ampicillin
+beta-lactam	blaSHV-74_1	AM176549	ampicillin
+beta-lactam	blaSHV-75_1	AM176550	ampicillin
+beta-lactam	blaSHV-76_1	AM176551	ampicillin
+beta-lactam	blaSHV-77_1	EF373975	ampicillin
+beta-lactam	blaSHV-78_1	AM176553	ampicillin
+beta-lactam	blaSHV-79_1	AM176554	ampicillin
+beta-lactam	blaSHV-8_1	U92041	ampicillin,ceftriaxone
+beta-lactam	blaSHV-80_1	AM176555	ampicillin
+beta-lactam	blaSHV-81_1	AM176556	ampicillin
+beta-lactam	blaSHV-82_1	AM176557	ampicillin
+beta-lactam	blaSHV-85_1	DQ322460	ampicillin
+beta-lactam	blaSHV-86_1	DQ328802	ampicillin,ceftriaxone
+beta-lactam	blaSHV-89_1	DQ193536	ampicillin
 beta-lactam	blaSHV-9_1	S82452	ampicillin,ceftriaxone
+beta-lactam	blaSHV-92_1	DQ836922	ampicillin
+beta-lactam	blaSHV-93_1	EF373969	ampicillin
+beta-lactam	blaSHV-94_1	EF373970	ampicillin
+beta-lactam	blaSHV-95_1	EF373972	ampicillin
+beta-lactam	blaSHV-96_1	EF373971	ampicillin
+beta-lactam	blaSHV-97_1	EF373973	ampicillin
+beta-lactam	blaSHV-98_1	AM941844	ampicillin,ceftriaxone
+beta-lactam	blaSHV-99_1	AM941845	ampicillin,ceftriaxone
+beta-lactam	blaSIM-1_1	JF731030	ampicillin
+beta-lactam	blaSMB-1_1	AB636283	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaSME-1_1	Z28968	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaSME-2_1	AF275256	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaSME-3_1	AY584237	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaSPG-1_1	KP109680	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaSPM-1_1	AY341249	ampicillin
+beta-lactam	blaSPU-1_1	GQ919044	ampicilin,ceftriaxone
+beta-lactam	blaSRT-1_1	AB008454	ampicilin,ceftriaxone
+beta-lactam	blaSRT-2_1	AY524276	ampicilin,ceftriaxone
+beta-lactam	blaSST-1_1	AB008455	ampicilin,ceftriaxone
+beta-lactam	blaTEM-10_1	AF093512	ampicillin,ceftriaxone
+beta-lactam	blaTEM-101_1	AF495873	ampicillin,ceftriaxone
+beta-lactam	blaTEM-102_1	AY040093	ampicillin,ceftriaxone
+beta-lactam	blaTEM-104_1	AF516719	ampicillin
+beta-lactam	blaTEM-105_1	AF516720	ampicillin
+beta-lactam	blaTEM-106_1	AY101578	ampicillin,ceftriaxone
+beta-lactam	blaTEM-107_1	AY101764	ampicillin,ceftriaxone
+beta-lactam	blaTEM-108_1	AF506748	ampicillin
+beta-lactam	blaTEM-109_1	AY628175	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-11_1	AY874537	ampicillin,ceftriaxone
+beta-lactam	blaTEM-110_1	AY072920	ampicillin
+beta-lactam	blaTEM-111_1	AF468003	ampicillin
+beta-lactam	blaTEM-112_1	AY589493	ampicillin,ceftriaxone
+beta-lactam	blaTEM-113_1	AY589494	ampicillin,ceftriaxone
+beta-lactam	blaTEM-114_1	AY589495	ampicillin,ceftriaxone
+beta-lactam	blaTEM-115_1	AF535127	ampicillin,ceftriaxone
 beta-lactam	blaTEM-116_1	AY425988	ampicillin
+beta-lactam	blaTEM-12_1	M88143	ampicillin,ceftriaxone
+beta-lactam	blaTEM-120_1	AY243512	ampicillin,ceftriaxone
+beta-lactam	blaTEM-121_1	AY307374	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-122_1	AY307100	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-123_1	AY327539	ampicillin,ceftriaxone
+beta-lactam	blaTEM-124_1	AY327540	ampicillin,ceftriaxone
+beta-lactam	blaTEM-125_1	AY628176	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-126_1	AY628199	ampicillin,ceftriaxone
+beta-lactam	blaTEM-127_1	AY368236	ampicillin
+beta-lactam	blaTEM-128_1	AY368237	ampicillin
+beta-lactam	blaTEM-129_1	AJ746225	ampicillin,ceftriaxone
+beta-lactam	blaTEM-130_1	AJ866988	ampicillin,ceftriaxone
+beta-lactam	blaTEM-131_1	AY436361	ampicillin,ceftriaxone
+beta-lactam	blaTEM-132_1	AY491682	ampicillin,ceftriaxone
+beta-lactam	blaTEM-133_1	AY528425	ampicillin,ceftriaxone
+beta-lactam	blaTEM-134_1	AY574271	ampicillin,ceftriaxone
+beta-lactam	blaTEM-135_1	GQ896333	ampicillin
+beta-lactam	blaTEM-136_1	AY826417	ampicillin,ceftriaxone
+beta-lactam	blaTEM-137_1	AM286274	ampicillin,ceftriaxone
+beta-lactam	blaTEM-138_1	AY853593	ampicillin,ceftriaxone
+beta-lactam	blaTEM-139_1	DQ072853	ampicillin,ceftriaxone
+beta-lactam	blaTEM-141_1	AY956335	ampicillin
+beta-lactam	blaTEM-142_1	DQ388882	ampicillin
+beta-lactam	blaTEM-143_1	DQ075245	ampicillin,ceftriaxone
+beta-lactam	blaTEM-144_1	AM049400	ampicillin,ceftriaxone
+beta-lactam	blaTEM-145_1	DQ105528	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-146_1	DQ105529	ampicillin
+beta-lactam	blaTEM-147_1	DQ279850	ampicillin,ceftriaxone
+beta-lactam	blaTEM-148_1	AM087454	ampicillin
+beta-lactam	blaTEM-149_1	DQ369751	ampicillin,ceftriaxone
+beta-lactam	blaTEM-15_1	AM849805	ampicillin,ceftriaxone
+beta-lactam	blaTEM-150_1	AM183304	ampicillin
+beta-lactam	blaTEM-151_1	DQ834729	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-152_1	DQ834728	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-153_1	KC149518	ampicillin,ceftriaxone
+beta-lactam	blaTEM-154_1	FJ807656	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
+beta-lactam	blaTEM-155_1	DQ679961	ampicillin,ceftriaxone
+beta-lactam	blaTEM-156_1	AM941159	ampicillin
+beta-lactam	blaTEM-157_1	DQ909059	ampicillin,ceftriaxone
+beta-lactam	blaTEM-158_1	EF534736	ampicillin
+beta-lactam	blaTEM-159_1	EF136376	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-16_1	X65254	ampicillin,ceftriaxone
+beta-lactam	blaTEM-160_1	EF136377	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-162_1	EF468463	ampicillin
+beta-lactam	blaTEM-163_1	EU815939	ampicillin
+beta-lactam	blaTEM-164_1	EU274580	ampicillin,ceftriaxone
+beta-lactam	blaTEM-166_1	FJ197316	ampicillin
+beta-lactam	blaTEM-167_1	FJ360884	ampicillin
+beta-lactam	blaTEM-168_1	FJ919776	ampicillin
+beta-lactam	blaTEM-169_1	KP012538	ampicillin,ceftriaxone
+beta-lactam	blaTEM-17_1	Y14574	ampicillin,ceftriaxone
+beta-lactam	blaTEM-171_1	GQ149347	ampicillin
+beta-lactam	blaTEM-176_1	GU550123	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-177_1	FN652295	ampicillin,ceftriaxone
+beta-lactam	blaTEM-178_1	X97254	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
 beta-lactam	blaTEM-181_1	KM977568	ampicillin
+beta-lactam	blaTEM-182_1	HQ317449	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-183_1	HQ529916	ampicillin
+beta-lactam	blaTEM-184_1	FR848831	ampicillin,ceftriaxone
+beta-lactam	blaTEM-185_1	JF795538	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-186_1	JN227084	ampicillin
+beta-lactam	blaTEM-187_1	HM246246	ampicillin,ceftriaxone
+beta-lactam	blaTEM-188_1	JN211012	ampicillin,ceftriaxone
+beta-lactam	blaTEM-189_1	JN254627	ampicillin
 beta-lactam	blaTEM-19_1	JX042489	ampicillin
+beta-lactam	blaTEM-190_1	JN416112	ampicillin
 beta-lactam	blaTEM-191_1	KY432484	ampicillin
+beta-lactam	blaTEM-193_1	JN935135	ampicillin
+beta-lactam	blaTEM-194_1	JN935136	ampicillin
+beta-lactam	blaTEM-195_1	JN935137	ampicillin
 beta-lactam	blaTEM-196_1	JQ034306	ampicillin
+beta-lactam	blaTEM-197_1	HQ877606	ampicillin,ceftriaxone
+beta-lactam	blaTEM-198_1	AB700703	ampicillin
 beta-lactam	blaTEM-1A_1	HM749966	ampicillin
+beta-lactam	blaTEM-1B_1	AY458016	ampicillin
 beta-lactam	blaTEM-1C_1	FJ560503	ampicillin
 beta-lactam	blaTEM-1D_1	AF188200	ampicillin
+beta-lactam	blaTEM-2_1	X54606	ampicillin
 beta-lactam	blaTEM-2_2	AJ251946	ampicillin
+beta-lactam	blaTEM-20_1	EU527189	ampicillin,ceftriaxone
+beta-lactam	blaTEM-201_1	JX310327	ampicillin
+beta-lactam	blaTEM-205_1	KC900516	ampicillin
+beta-lactam	blaTEM-206_1	KC783461	ampicillin
+beta-lactam	blaTEM-207_1	KC818234	ampicillin,ceftriaxone
+beta-lactam	blaTEM-208_1	KC865667	ampicillin
+beta-lactam	blaTEM-209_1	KF240808	ampicillin
+beta-lactam	blaTEM-21_1	Y17582	ampicillin,ceftriaxone
 beta-lactam	blaTEM-210_1	KJ484630	ampicillin
+beta-lactam	blaTEM-211_1	KF513179	ampicillin,ceftriaxone
 beta-lactam	blaTEM-212_1	KF481968	ampicillin
+beta-lactam	blaTEM-213_1	LJEE02000034	ampicillin
 beta-lactam	blaTEM-214_1	KP050491	ampicillin
 beta-lactam	blaTEM-215_1	KP050492	ampicillin
 beta-lactam	blaTEM-216_1	KF944358	ampicillin
 beta-lactam	blaTEM-217_1	HG934763	ampicillin
 beta-lactam	blaTEM-219_1	KM114268	ampicillin
+beta-lactam	blaTEM-22_1	Y17583	ampicillin,ceftriaxone
 beta-lactam	blaTEM-220_1	KM998962	ampicillin
 beta-lactam	blaTEM-224_1	KU664545	ampicillin
 beta-lactam	blaTEM-225_1	KY432403	ampicillin
@@ -775,15 +1928,116 @@ beta-lactam	blaTEM-231_1	MG821378	ampicillin
 beta-lactam	blaTEM-232_1	MH079593	ampicillin
 beta-lactam	blaTEM-233_1	MH270416	ampicillin
 beta-lactam	blaTEM-234_1	MH243353	ampicillin
+beta-lactam	blaTEM-24_1	GQ293500	ampicillin,ceftriaxone
 beta-lactam	blaTEM-26_1	LDCJ01000052	ampicillin
+beta-lactam	blaTEM-28_1	U37195	ampicillin,ceftriaxone
+beta-lactam	blaTEM-29_1	DQ269440	ampicillin,ceftriaxone
+beta-lactam	blaTEM-3_1	X64523	ampicillin,ceftriaxone
+beta-lactam	blaTEM-30_1	AJ437107	ampicillin,amoxicillin/clavulanic acid
 beta-lactam	blaTEM-32_1	CXLQ01000061	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-33_1	GU371926	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-34_1	KC292503	ampicillin,amoxicillin/clavulanic acid
 beta-lactam	blaTEM-35_1	KP860986	ampicillin,amoxicillin/clavulanic acid
 beta-lactam	blaTEM-36_1	KY305958	ampicillin,amoxicillin/clavulanic acid
 beta-lactam	blaTEM-4_1	LK391770	ampicillin
 beta-lactam	blaTEM-40_1	FR717535	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-43_1	U95363	ampicillin,ceftriaxone
+beta-lactam	blaTEM-45_1	X95401	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-47_1	Y10279	ampicillin,ceftriaxone
+beta-lactam	blaTEM-48_1	Y10280	ampicillin,ceftriaxone
+beta-lactam	blaTEM-49_1	Y10281	ampicillin,ceftriaxone
 beta-lactam	blaTEM-52_1	Y13612	ampicillin
+beta-lactam	blaTEM-52B_1	AF027199	ampicillin,ceftriaxone
+beta-lactam	blaTEM-52C_2	EF141186	ampicillin,ceftriaxone
+beta-lactam	blaTEM-53_1	AF104441	ampicillin,ceftriaxone
+beta-lactam	blaTEM-54_1	AF104442	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-55_1	DQ286729	ampicillin
+beta-lactam	blaTEM-57_1	FJ405211	ampicillin
+beta-lactam	blaTEM-6_1	X57972	ampicillin,ceftriaxone
+beta-lactam	blaTEM-60_1	AF047171	ampicillin,ceftriaxone
+beta-lactam	blaTEM-63_1	AF332513	ampicillin,ceftriaxone
+beta-lactam	blaTEM-67_1	AF091113	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-68_1	AJ239002	ampicillin
+beta-lactam	blaTEM-70_1	AF188199	ampicillin
+beta-lactam	blaTEM-71_1	AF203816	ampicillin
+beta-lactam	blaTEM-72_1	AF157553	ampicillin
+beta-lactam	blaTEM-76_1	AF190694	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-77_1	AF190695	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-78_1	AF190693	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-79_1	AF190692	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-8_1	X65252	ampicillin,ceftriaxone
+beta-lactam	blaTEM-80_1	AF347054	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-81_1	AF427127	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-82_1	AF427128	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-83_1	AF427129	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-84_1	AF427130	ampicillin,amoxicillin/clavulanic acid
+beta-lactam	blaTEM-85_1	AJ277414	ampicillin,ceftriaxone
+beta-lactam	blaTEM-86_1	AJ277415	ampicillin,ceftriaxone
+beta-lactam	blaTEM-87_1	AF250872	ampicillin,ceftriaxone
+beta-lactam	blaTEM-88_1	AY027590	ampicillin,ceftriaxone
 beta-lactam	blaTEM-9_1	KY271103	ampicillin
+beta-lactam	blaTEM-90_1	AF351241	ampicillin
+beta-lactam	blaTEM-91_1	AB049569	ampicillin,ceftriaxone
+beta-lactam	blaTEM-92_1	AF143804	ampicillin,ceftriaxone
+beta-lactam	blaTEM-93_1	AJ318093	ampicillin,ceftriaxone
+beta-lactam	blaTEM-94_1	AJ318094	ampicillin,ceftriaxone
+beta-lactam	blaTEM-95_1	AJ308558	ampicillin
+beta-lactam	blaTEM-96_1	AY092401	ampicillin
+beta-lactam	blaTEM-97_1	AF397067	ampicillin
+beta-lactam	blaTEM-98_1	AF397068	ampicillin
+beta-lactam	blaTEM-99_1	AF397066	ampicillin
+beta-lactam	blaTER-1_1	FJ263091	ampicillin
+beta-lactam	blaTER-2_1	FJ263090	ampicillin
+beta-lactam	blaTLA-1_1	AF148067	ampicillin
+beta-lactam	blaTMB-1_1	FR771847	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaTMB-2_1	AB758277	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaTRU_1	EU046614	ampicillin
+beta-lactam	blaTUS-1_1	AF441287	ampicillin
+beta-lactam	blaVCC-1_1	KT818596	ampicillin,meropenem
+beta-lactam	blaVEB-1_1	HM370393	ampicillin,ceftriaxone
+beta-lactam	blaVEB-1_3	DQ393569	ampicillin,ceftriaxone
+beta-lactam	blaVEB-1_4	AF324834	ampicillin,ceftriaxone
+beta-lactam	blaVEB-2_1	AY027870	ampicillin,ceftriaxone
+beta-lactam	blaVEB-3_1	AY536519	ampicillin,ceftriaxone
+beta-lactam	blaVEB-4_1	EF136375	ampicillin,ceftriaxone
+beta-lactam	blaVEB-5_1	EF420108	ampicillin,ceftriaxone
+beta-lactam	blaVEB-6_1	EU259884	ampicillin,ceftriaxone
+beta-lactam	blaVEB-7_1	FJ825622	ampicillin,ceftriaxone
+beta-lactam	blaVEB-8_1	JX679208	ampicillin,ceftriaxone
+beta-lactam	blaVHH-1_1	NG050334	ampicillin
+beta-lactam	blaVHW-1_1	AF217648	ampicillin
+beta-lactam	blaVIM-1_1	Y18050	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-10_1	AY524989	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-11_1	AY605049	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-12_1	DQ143913	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-13_1	DQ365886	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-14_1	FJ445404	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-15_1	EU419745	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-16_1	EU419746	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-17_1	EU118148	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-18_1	AM778091	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-19_1	FJ499397	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-2_1	AF302086	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-20_1	GQ414736	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-23_1	GQ242167	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-24_1	HM855205	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-25_1	HM750249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-26_1	FR748153	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-27_1	HQ858608	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-28_1	JF900599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-29_1	JX311308	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-3_1	AF300454	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-30_1	JN129451	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-31_1	JN982330	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-32_1	JN676230	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-33_1	JX258134	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-34_1	JX013656	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-35_1	JX982634	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-36_1	JX982635	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-37_1	JX982636	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-38_1	KC469971	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-39_1	KF131539	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-4_1	EU581706	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-40_1	HG934765	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-41_1	KP771862	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-42_1	KP071470	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
@@ -794,12 +2048,17 @@ beta-lactam	blaVIM-46_1	KP749829	ampicillin,amoxicillin/clavulanic acid,cefoxiti
 beta-lactam	blaVIM-47_1	KT954134	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-48_1	KY362199	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-49_1	KU663374	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-5_1	DQ023222	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-50_1	KU663375	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-51_1	KU746270	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-52_1	KX349731	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-54_1	KY508061	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-56_1	MG834535	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaVIM-57_1	MH450217	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-6_1	AY165025	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-7_1	AJ536835	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-8_1	AY524987	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	blaVIM-9_1	AY524988	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 beta-lactam	blaZ_1	CP000704	ampicillin
 beta-lactam	blaZ_10	FR823292	ampicillin
 beta-lactam	blaZ_100	LTMH01000008	ampicillin
@@ -861,6 +2120,17 @@ beta-lactam	blaZ_26	JBJP01000007	ampicillin
 beta-lactam	blaZ_27	JDGZ01000043	ampicillin
 beta-lactam	blaZ_28	JDYO01000009	ampicillin
 beta-lactam	blaZ_29	JDXN01000019	ampicillin
+beta-lactam	blaZ_3	CP000732	ampicillin
+beta-lactam	blaZ_30	JGUQ01000012	ampicillin
+beta-lactam	blaZ_31	JIFU01000008	ampicillin
+beta-lactam	blaZ_32	JINH01000005	ampicillin
+beta-lactam	blaZ_33	JIXQ01000012	ampicillin
+beta-lactam	blaZ_34	JJAO01000008	ampicillin
+beta-lactam	blaZ_35	JIVZ01000012	ampicillin
+beta-lactam	blaZ_36	JITV01000006	ampicillin
+beta-lactam	blaZ_37	JIFD01000012	ampicillin
+beta-lactam	blaZ_38	NZ_JEMM01000040	ampicillin
+beta-lactam	blaZ_39	JHTU01000073	ampicillin
 beta-lactam	blaZ_4	X04121	ampicillin
 beta-lactam	blaZ_40	NZ_AZBT01000050	ampicillin
 beta-lactam	blaZ_41	AENR01000015	ampicillin
@@ -927,6 +2197,43 @@ beta-lactam	blaZ_96	LNDI01000019	ampicillin
 beta-lactam	blaZ_97	FMOK01000003	ampicillin
 beta-lactam	blaZ_98	LTEF01000041	ampicillin
 beta-lactam	blaZ_99	LTNH01000008	ampicillin
+beta-lactam	blaZEG-1_1	AY265891	ampicillin
+beta-lactam	cepA_1	L13472	ampicillin
+beta-lactam	cepA_1	U05887	ampicillin
+beta-lactam	cepA_6	FR688022	ampicillin
+beta-lactam	cepA-29_1	U05884	ampicillin
+beta-lactam	cepA-44_1	U05885	ampicillin
+beta-lactam	cepA-49_1	U05886	ampicillin
+beta-lactam	cfiA1_1	AB087225	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA10_1	AB087227	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA13_1	FM200787	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA14_1	FM200789	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA2_1	AB087226	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA3_1	AB087228	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA4_1	AB087229	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA6_1	AB087231	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA8_1	AB087233	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfiA9_1	AB087234	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
+beta-lactam	cfxA_1	U38243	ampicillin
+beta-lactam	cfxA2_1	AF504914	ampicillin
+beta-lactam	cfxA3_1	AF472622	ampicillin
+beta-lactam	cfxA4_1	AY769933	ampicillin
+beta-lactam	cfxA5_1	AY769934	ampicillin
+beta-lactam	cfxA6_1	GQ342996	ampicillin
+beta-lactam	cphA1_1	AY261379	ampicillin
+beta-lactam	cphA1_2	AY261377	ampicillin
+beta-lactam	cphA1_3	AY261378	ampicillin
+beta-lactam	cphA1_4	AY261376	ampicillin
+beta-lactam	cphA1_7	X57102	ampicillin
+beta-lactam	cphA2_6	AHU60294	ampicillin
+beta-lactam	cphA4_1	AY227050	ampicillin
+beta-lactam	cphA5_1	AY227051	ampicillin
+beta-lactam	cphA6_1	AY227052	ampicillin
+beta-lactam	cphA7_1	AY227053	ampicillin
+beta-lactam	cphA8_1	AY261375	ampicillin
+beta-lactam	hugA_1	AF324468	ampicillin
+beta-lactam	imiH_1	AJ548797	ampicillin
+beta-lactam	imiS_1	Y10415	ampicillin
 beta-lactam	mecA_1	NC_002745	penicillin
 beta-lactam	mecA_2	NC_002951	penicillin
 beta-lactam	mecA_3	Y13095	penicillin
@@ -950,1315 +2257,8 @@ beta-lactam	mecC_3	KR732654	penicillin
 beta-lactam	mecC_4	HG515014	penicillin
 beta-lactam	mecC2_1	KF955540	penicillin
 beta-lactam	mecD_1	KY013611	penicillin
-beta-lactam	blaFRI-1_1	KT192551	ampicillin,meropenem
-beta-lactam	blaOXA-23_1	AY795964	ampicillin,meropenem
-beta-lactam	blaOXA-24_1	AJ239129	ampicillin,meropenem
-beta-lactam	blaOXA-48_1	AY236073	ampicillin,amoxicillin/clavulanic acid,decreased susceptibility to meropenem
-beta-lactam	blaOXA-51_1	DQ385606	ampicillin,meropenem
-beta-lactam	blaOXA-58_1	AY665723	ampicillin,meropenem
-beta-lactam	blaSFC-1_1	AY354402	ampicillin,meropenem
-beta-lactam	blaCTX-M-10_1	AY598759	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-100_1	FR682582	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-101_1	HQ398214	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-102_1	HQ398215	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-103_1	HG423149	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-104_1	HQ833652	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-105_1	HQ833651	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-110_1	JF274242	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-111_1	JF274243	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-112_1	JF274246	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-113_1	JF274247	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-114_1	GQ351346	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-116_1	JF966749	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-117_1	JN227085	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-12_1	DQ821704	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-121_1	JN790862	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-123_1	JN790864	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-124_1	JQ429324	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-125_1	JQ724542	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-126_1	AB703103	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-129_1	JX017364	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-13_2	AF252623	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-130_1	JX017365	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-131_1	JN969893	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-132_1	JX313020	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-134_1	JX896165	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-136_1	KC351754	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-139_1	KC107824	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-14_1	AF252622	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-142_1	KF240809	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-147_1	KF513180	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-14b_1	DQ359215	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-16_1	AY029068	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-17_1	AY033516	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-19_1	AF325134	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-2_1	AB176535	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-20_1	AJ416344	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-21_1	AJ416346	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-22_1	AY080894	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-23_1	AF488377	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-24_1	EF374096	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-25_1	AF518567	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-26_1	AY157676	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-27_1	AY156923	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-28_6	AJ549244	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-29_1	AY267213	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-30_1	AY292654	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-31_1	AJ567481	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-32_2	AJ557142	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-33_1	AY238472	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-34_1	AY515297	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-35_1	AB176532	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-36_1	AB177384	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-38_1	AY822595	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-39_1	AY954516	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-4_1	Y14156	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-40_1	AY750914	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-41_1	DQ023162	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-42_1	DQ061159	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-43_1	DQ102702	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-44_1	D37830	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-46_1	AY847147	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-47_1	AY847143	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-48_1	AY847144	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-49_1	AY847145	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-50_1	AY847146	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-51_1	DQ211987	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-52_1	DQ223685	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-53_1	DQ268764	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-54_1	DQ303459	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-56_1	EF374097	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-58_1	EF210159	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-59_1	DQ408762	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-6_1	AJ005044	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-60_1	AM411407	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-61_1	EF219142	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-62_1	EF219134	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-63_1	AB205197	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-63_1	EU660216	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-64_1	AB284167	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-65_1	EF418608	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-66_1	EF576988	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-67_1	EF581888	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-68_1	EU177100	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-69_1	EU402393	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-71_1	FJ815436	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-72_1	AY847148	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-74_1	GQ149243	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-75_1	GQ149244	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-76_1	AM982520	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-77_1	AM982521	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-78_1	AM982522	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-79_1	EF426798	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-8_1	AF189721	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-80_1	EU202673	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-81_1	EU136031	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-82_1	DQ256091	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-83_1	FJ214366	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-84_1	FJ214367	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-85_1	FJ214368	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-86_1	FJ214369	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-87_1	EU545409	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-88_1	FJ873739	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-89_1	FJ971899	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-9_1	AF174129	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-90_1	FJ907381	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-91_1	GQ870432	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-92_1	GU127598	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-93_1	HQ166709	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-94_1	HM167760	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-95_1	FN813245	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-96_1	AJ704396	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-97_1	HM776707	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-98_1	HM755448	ampicillin,ceftriaxone
-beta-lactam	blaCTX-M-99_1	HM803271	ampicillin,ceftriaxone
-beta-lactam	blaOXA-11_1	Z22590	ampicillin,ceftriaxone
-beta-lactam	blaOXA-14_1	KJ420612	ampicillin,ceftriaxone
-beta-lactam	blaOXA-141_1	EF552405	ampicillin,ceftriaxone
-beta-lactam	blaOXA-142_1	LC169567	ampicillin,ceftriaxone
-beta-lactam	blaOXA-145_1	FJ790516	ampicillin,ceftriaxone
-beta-lactam	blaOXA-147_1	FJ848783	ampicillin,ceftriaxone
-beta-lactam	blaOXA-15_1	U63835	ampicillin,ceftriaxone
-beta-lactam	blaOXA-16_1	AF043100	ampicillin,ceftriaxone
-beta-lactam	blaOXA-161_1	GQ202693	ampicillin,ceftriaxone
-beta-lactam	blaOXA-19_1	AF043381	ampicillin,ceftriaxone
-beta-lactam	blaOXA-28_1	AF231133	ampicillin,ceftriaxone
-beta-lactam	blaOXA-32_1	AF315351	ampicillin,ceftriaxone
-beta-lactam	blaOXA-35_1	AF315786	ampicillin,ceftriaxone
-beta-lactam	blaOXA-36_1	AF300985	ampicillin,ceftriaxone
-beta-lactam	blaOXA-37_1	AY007784	ampicillin,ceftriaxone
-beta-lactam	blaPER-1_1	GU944725	ampicillin,ceftriaxone
-beta-lactam	blaPER-2_1	X93314	ampicillin,ceftriaxone
-beta-lactam	blaPER-3_1	AY740681	ampicillin,ceftriaxone
-beta-lactam	blaPER-4_1	EU748544	ampicillin,ceftriaxone
-beta-lactam	blaPER-5_1	FJ627180	ampicillin,ceftriaxone
-beta-lactam	blaPER-6_1	GQ396303	ampicillin,ceftriaxone
-beta-lactam	blaPER-7_1	HQ713678	ampicillin,ceftriaxone
-beta-lactam	blaRAHN-1_1	GU645205	ampicillin,ceftriaxone
-beta-lactam	blaRAHN-1_2	AF338038	ampicillin,ceftriaxone
-beta-lactam	blaRAHN-2_2	HM114350	ampicillin,ceftriaxone
-beta-lactam	blaSHV-100_1	AM941846	ampicillin,ceftriaxone
-beta-lactam	blaSHV-104_1	EU274581	ampicillin,ceftriaxone
-beta-lactam	blaSHV-105_1	FJ194944	ampicillin,ceftriaxone
-beta-lactam	blaSHV-12_1	KF976405	ampicillin,ceftriaxone
-beta-lactam	blaSHV-13_1	AF164577	ampicillin,ceftriaxone
-beta-lactam	blaSHV-134_1	HM559945	ampicillin,ceftriaxone
-beta-lactam	blaSHV-15_1	AJ011428	ampicillin,ceftriaxone
-beta-lactam	blaSHV-16_1	AF072684	ampicillin,ceftriaxone
-beta-lactam	blaSHV-18_1	AF132290	ampicillin,ceftriaxone
-beta-lactam	blaSHV-2_1	AF148851	ampicillin,ceftriaxone
-beta-lactam	blaSHV-24_1	AB023477	ampicillin,ceftriaxone
-beta-lactam	blaSHV-2a_1	X98102	ampicillin,ceftriaxone
-beta-lactam	blaSHV-30_1	AY661885	ampicillin,ceftriaxone
-beta-lactam	blaSHV-31_1	AY277255	ampicillin,ceftriaxone
-beta-lactam	blaSHV-38_1	AY079099	ampicillin,ceftriaxone
-beta-lactam	blaSHV-40_1	AF535128	ampicillin,ceftriaxone
-beta-lactam	blaSHV-41_1	AF535129	ampicillin,ceftriaxone
-beta-lactam	blaSHV-42_1	AF535130	ampicillin,ceftriaxone
-beta-lactam	blaSHV-45_1	AF547625	ampicillin,ceftriaxone
-beta-lactam	blaSHV-46_1	AY210887	ampicillin,ceftriaxone
-beta-lactam	blaSHV-5_1	X55640	ampicillin,ceftriaxone
-beta-lactam	blaSHV-55_1	DQ054528	ampicillin,ceftriaxone
-beta-lactam	blaSHV-57_1	AY223863	ampicillin,ceftriaxone
-beta-lactam	blaSHV-64_1	DQ174304	ampicillin,ceftriaxone
-beta-lactam	blaSHV-66_1	DQ174306	ampicillin,ceftriaxone
-beta-lactam	blaSHV-7_1	U20270	ampicillin,ceftriaxone
-beta-lactam	blaSHV-70_1	DQ013287	ampicillin,ceftriaxone
-beta-lactam	blaSHV-8_1	U92041	ampicillin,ceftriaxone
-beta-lactam	blaSHV-86_1	DQ328802	ampicillin,ceftriaxone
-beta-lactam	blaSHV-98_1	AM941844	ampicillin,ceftriaxone
-beta-lactam	blaSHV-99_1	AM941845	ampicillin,ceftriaxone
-beta-lactam	blaTEM-10_1	AF093512	ampicillin,ceftriaxone
-beta-lactam	blaTEM-101_1	AF495873	ampicillin,ceftriaxone
-beta-lactam	blaTEM-102_1	AY040093	ampicillin,ceftriaxone
-beta-lactam	blaTEM-106_1	AY101578	ampicillin,ceftriaxone
-beta-lactam	blaTEM-107_1	AY101764	ampicillin,ceftriaxone
-beta-lactam	blaTEM-11_1	AY874537	ampicillin,ceftriaxone
-beta-lactam	blaTEM-112_1	AY589493	ampicillin,ceftriaxone
-beta-lactam	blaTEM-113_1	AY589494	ampicillin,ceftriaxone
-beta-lactam	blaTEM-114_1	AY589495	ampicillin,ceftriaxone
-beta-lactam	blaTEM-115_1	AF535127	ampicillin,ceftriaxone
-beta-lactam	blaTEM-12_1	M88143	ampicillin,ceftriaxone
-beta-lactam	blaTEM-120_1	AY243512	ampicillin,ceftriaxone
-beta-lactam	blaTEM-123_1	AY327539	ampicillin,ceftriaxone
-beta-lactam	blaTEM-124_1	AY327540	ampicillin,ceftriaxone
-beta-lactam	blaTEM-126_1	AY628199	ampicillin,ceftriaxone
-beta-lactam	blaTEM-129_1	AJ746225	ampicillin,ceftriaxone
-beta-lactam	blaTEM-130_1	AJ866988	ampicillin,ceftriaxone
-beta-lactam	blaTEM-131_1	AY436361	ampicillin,ceftriaxone
-beta-lactam	blaTEM-132_1	AY491682	ampicillin,ceftriaxone
-beta-lactam	blaTEM-133_1	AY528425	ampicillin,ceftriaxone
-beta-lactam	blaTEM-134_1	AY574271	ampicillin,ceftriaxone
-beta-lactam	blaTEM-136_1	AY826417	ampicillin,ceftriaxone
-beta-lactam	blaTEM-137_1	AM286274	ampicillin,ceftriaxone
-beta-lactam	blaTEM-138_1	AY853593	ampicillin,ceftriaxone
-beta-lactam	blaTEM-139_1	DQ072853	ampicillin,ceftriaxone
-beta-lactam	blaTEM-143_1	DQ075245	ampicillin,ceftriaxone
-beta-lactam	blaTEM-144_1	AM049400	ampicillin,ceftriaxone
-beta-lactam	blaTEM-147_1	DQ279850	ampicillin,ceftriaxone
-beta-lactam	blaTEM-149_1	DQ369751	ampicillin,ceftriaxone
-beta-lactam	blaTEM-15_1	AM849805	ampicillin,ceftriaxone
-beta-lactam	blaTEM-153_1	KC149518	ampicillin,ceftriaxone
-beta-lactam	blaTEM-155_1	DQ679961	ampicillin,ceftriaxone
-beta-lactam	blaTEM-157_1	DQ909059	ampicillin,ceftriaxone
-beta-lactam	blaTEM-16_1	X65254	ampicillin,ceftriaxone
-beta-lactam	blaTEM-164_1	EU274580	ampicillin,ceftriaxone
-beta-lactam	blaTEM-169_1	KP012538	ampicillin,ceftriaxone
-beta-lactam	blaTEM-17_1	Y14574	ampicillin,ceftriaxone
-beta-lactam	blaTEM-177_1	FN652295	ampicillin,ceftriaxone
-beta-lactam	blaTEM-184_1	FR848831	ampicillin,ceftriaxone
-beta-lactam	blaTEM-187_1	HM246246	ampicillin,ceftriaxone
-beta-lactam	blaTEM-188_1	JN211012	ampicillin,ceftriaxone
-beta-lactam	blaTEM-197_1	HQ877606	ampicillin,ceftriaxone
-beta-lactam	blaTEM-20_1	EU527189	ampicillin,ceftriaxone
-beta-lactam	blaTEM-207_1	KC818234	ampicillin,ceftriaxone
-beta-lactam	blaTEM-21_1	Y17582	ampicillin,ceftriaxone
-beta-lactam	blaTEM-211_1	KF513179	ampicillin,ceftriaxone
-beta-lactam	blaTEM-22_1	Y17583	ampicillin,ceftriaxone
-beta-lactam	blaTEM-24_1	GQ293500	ampicillin,ceftriaxone
-beta-lactam	blaTEM-28_1	U37195	ampicillin,ceftriaxone
-beta-lactam	blaTEM-29_1	DQ269440	ampicillin,ceftriaxone
-beta-lactam	blaTEM-3_1	X64523	ampicillin,ceftriaxone
-beta-lactam	blaTEM-43_1	U95363	ampicillin,ceftriaxone
-beta-lactam	blaTEM-47_1	Y10279	ampicillin,ceftriaxone
-beta-lactam	blaTEM-48_1	Y10280	ampicillin,ceftriaxone
-beta-lactam	blaTEM-49_1	Y10281	ampicillin,ceftriaxone
-beta-lactam	blaTEM-52B_1	AF027199	ampicillin,ceftriaxone
-beta-lactam	blaTEM-52C_2	EF141186	ampicillin,ceftriaxone
-beta-lactam	blaTEM-53_1	AF104441	ampicillin,ceftriaxone
-beta-lactam	blaTEM-6_1	X57972	ampicillin,ceftriaxone
-beta-lactam	blaTEM-60_1	AF047171	ampicillin,ceftriaxone
-beta-lactam	blaTEM-63_1	AF332513	ampicillin,ceftriaxone
-beta-lactam	blaTEM-8_1	X65252	ampicillin,ceftriaxone
-beta-lactam	blaTEM-85_1	AJ277414	ampicillin,ceftriaxone
-beta-lactam	blaTEM-86_1	AJ277415	ampicillin,ceftriaxone
-beta-lactam	blaTEM-87_1	AF250872	ampicillin,ceftriaxone
-beta-lactam	blaTEM-88_1	AY027590	ampicillin,ceftriaxone
-beta-lactam	blaTEM-91_1	AB049569	ampicillin,ceftriaxone
-beta-lactam	blaTEM-92_1	AF143804	ampicillin,ceftriaxone
-beta-lactam	blaTEM-93_1	AJ318093	ampicillin,ceftriaxone
-beta-lactam	blaTEM-94_1	AJ318094	ampicillin,ceftriaxone
-beta-lactam	blaVEB-1_1	HM370393	ampicillin,ceftriaxone
-beta-lactam	blaVEB-1_3	DQ393569	ampicillin,ceftriaxone
-beta-lactam	blaVEB-1_4	AF324834	ampicillin,ceftriaxone
-beta-lactam	blaVEB-2_1	AY027870	ampicillin,ceftriaxone
-beta-lactam	blaVEB-3_1	AY536519	ampicillin,ceftriaxone
-beta-lactam	blaVEB-4_1	EF136375	ampicillin,ceftriaxone
-beta-lactam	blaVEB-5_1	EF420108	ampicillin,ceftriaxone
-beta-lactam	blaVEB-6_1	EU259884	ampicillin,ceftriaxone
-beta-lactam	blaVEB-7_1	FJ825622	ampicillin,ceftriaxone
-beta-lactam	blaVEB-8_1	JX679208	ampicillin,ceftriaxone
-beta-lactam	blaTEM-109_1	AY628175	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-121_1	AY307374	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-125_1	AY628176	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-151_1	DQ834729	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-152_1	DQ834728	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-154_1	FJ807656	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaTEM-178_1	X97254	ampicillin,amoxicillin/clavulanic acid,ceftriaxone
-beta-lactam	blaB-10_1	AY348325	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-11_1	AY348326	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-12_1	EF595958	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-13_1	EF595959	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-14_1	JN635697	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-2_1	AF189300	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-3_1	AF189301	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-3_2	AF189299	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-5_1	AF189303	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-6_1	AF189302	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-7_1	AF189304	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-8_1	AF189305	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaB-9_1	AY348324	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaBKC-1_1	KP689347	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-1_1	HQ170511	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-10_1	FJ820124	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-11_1	FJ854362	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-12_1	FN554543	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-13_1	GU169702	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-14_1	GU207844	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-15_1	GU208678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-16_1	HM173356	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-17_1	HQ874631	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-18_1	JQ028729	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-19_1	JN596280	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-2_1	AF326355	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-20_1	JN596280	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-21_1	JQ772478	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-22_1	JX023441	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-23_1	KF179354	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-3_1	AB113580	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-4_1	AB116723	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-5_1	DQ236171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-6_1	AY494718	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-7_1	HM453325	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-8_1	AF329699	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGES-9_1	AY920928	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-1_1	EF394442	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-1_2	AF090141	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-10_1	AY647247	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-11_1	AY647248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-12_1	AY647249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-13_1	AY647251	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-14_1	AY647252	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-15_1	AY775547	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-16_1	GU188443	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-16_2	AY899331	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-17_1	AY899332	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-18_1	DQ004496	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-2_1	AF189296	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-3_1	AF189291	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-4_1	AF189293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-5_1	AF189290	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-6_1	AF189292	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-7_1	AF189297	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-8_1	AY348327	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaGOB-9_1	AY647246	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMI-1_1	U50278	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMI-2_1	DQ173429	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMI-3_1	GU015024	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMI-5_1	KT599915	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-1_1	EF027105	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-10_1	AB074435	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-11_1	AB074436	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-12_1	AJ420864	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-13_1	AJ550807	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-14_1	AY553332	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-15_1	AY553333	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-16_1	AJ584652	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-18_1	AY780674	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-19_1	EF118171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-2_1	AJ243491	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-20_1	AB196988	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-22_2	DQ361087	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-24_1	EF192154	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-25_1	EU541448	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-26_1	GU045307	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-27_1	JF894248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-28_1	JQ407409	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-29_1	HQ438058	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-3_1	AB010417	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-31_1	KF148593	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-32_1	JQ002629	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-33_1	JN848782	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-34_1	AB715422	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-35_1	JF816544	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-37_1	JX131372	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-38_1	HQ875573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-4_1	AF244145	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-4_1	DQ307573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-40_1	AB753457	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-41_1	AB753458	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-42_1	AB753456	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-43_1	AB777500	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-44_1	AB777501	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-5_1	AF290912	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-58_1	KU647281	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-6_1	AB753460	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-7_1	AF318077	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-8_1	DQ845788	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIMP-9_1	FJ655384	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-1_1	AF099139	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-10_1	GU206353	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-11_1	HM245379	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-12_1	HM245380	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-14_1	HM367709	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-15_1	AB563173	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-2_2	AF219127	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-2a_4	AF219130	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-2b_3	EF672681	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-2c_1	GU186042	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-3_1	AF219131	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-4_1	AF219135	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-5_1	AY504627	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-6_1	AM087455	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-7_1	AB529520	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-8_1	GU186044	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaIND-9_1	GU186045	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-10_1	GQ140348	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-11_1	HM066995	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-12_1	HQ641422	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-13_1	HQ342889	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-14_1	JX524191	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-15_1	KC433553	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-16_1	KC465199	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-2_1	AY034847	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-3_1	HM769262	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-4_1	FJ473382	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-5_1	EU400222	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-6_1	EU555534	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-7_1	EU729727	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-8_1	FJ234412	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaKPC-9_1	FJ624872	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-1_1	FN396876	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-10_1	KF361506	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-11_1	KP265939	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-12_1	AB926431	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-13_1	LC012596	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-14_1	KM210086	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-15_1	KP735848	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-16_1	KP862821	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-17_1	KX812714	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-18_1	KY503030	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-2_1	JF703135	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-3_1	JQ734687	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-4_1	JQ348841	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-5_1	JN104597	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-6_1	JN967644	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-7_1	JX262694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-8_1	AB744718	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaNDM-9_1	KC999080	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-151_1	CP009553	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-152_1	KP771980	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-153_1	KP771981	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-154_1	KP771982	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-155_1	KP771983	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-156_1	KP771984	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-157_1	KP771985	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-158_1	KP771986	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-159_1	KP771987	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-184_1	JQ396378	ampicillin
-beta-lactam	blaOXA-185_1	JQ396379	ampicillin
-beta-lactam	blaOXA-266_1	APPO01000008	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-274_1	APOS01000038	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-275_1	APPJ01000001	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-279_1	APOM01000058	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-286_1	APOI01000030	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-288_1	APRN01000033	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-291_1	APRL01000010	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-292_1	APRO01000007	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-294_1	APPC01000015	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-295_1	APRW01000016	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-296_1	APOH01000009	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-297_1	APRR01000006	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaOXA-427_1	KX827604	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaPAM-1_1	AB858498	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaPEDO-1_1	KP109677	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaPEDO-2_1	KP109678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaPEDO-3_1	KP109679	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaSMB-1_1	AB636283	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaSME-1_1	Z28968	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaSME-2_1	AF275256	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaSME-3_1	AY584237	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaSPG-1_1	KP109680	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaTMB-1_1	FR771847	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaTMB-2_1	AB758277	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVCC-1_1	KT818596	ampicillin,meropenem
-beta-lactam	blaVIM-1_1	Y18050	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-10_1	AY524989	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-11_1	AY605049	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-12_1	DQ143913	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-13_1	DQ365886	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-14_1	FJ445404	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-15_1	EU419745	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-16_1	EU419746	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-17_1	EU118148	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-18_1	AM778091	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-19_1	FJ499397	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-2_1	AF302086	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-20_1	GQ414736	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-23_1	GQ242167	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-24_1	HM855205	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-25_1	HM750249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-26_1	FR748153	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-27_1	HQ858608	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-28_1	JF900599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-29_1	JX311308	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-3_1	AF300454	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-30_1	JN129451	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-31_1	JN982330	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-32_1	JN676230	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-33_1	JX258134	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-34_1	JX013656	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-35_1	JX982634	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-36_1	JX982635	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-37_1	JX982636	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-38_1	KC469971	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-4_1	EU581706	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-5_1	DQ023222	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-6_1	AY165025	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-7_1	AJ536835	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-8_1	AY524987	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaVIM-9_1	AY524988	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA1_1	AB087225	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA10_1	AB087227	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA13_1	FM200787	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA14_1	FM200789	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA2_1	AB087226	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA3_1	AB087228	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA4_1	AB087229	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA6_1	AB087231	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA8_1	AB087233	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	cfiA9_1	AB087234	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	POM-1_1	GU002295	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
-beta-lactam	blaACC-1_2	HG530658	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACC-2_1	AF180952	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACC-3_1	AF180958	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACC-4_1	GU256641	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACC-4_1	KM087831	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-1_1	U58495	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-10_1	JN848330	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-12_1	JX440355	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-14_1	JX440354	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-15_1	JX440356	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-16_1	AB737978	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-2_1	AM076977	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-3_1	EF125013	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-4_2	AJ311172	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-5_1	FJ237369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-6_1	FJ237366	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-7_1	FJ237368	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaACT-9_1	HQ693810	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaBEL-1_1	DQ089809	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaBEL-2_1	FJ666063	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaBEL-3_1	GQ202694	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCFE-1_1	AB107899	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-1_1	X92508	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-10_1	AF381615	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-104_1	KF150216	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-11_1	AF357599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-110_1	AB872957	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-12_1	Y16785	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-13_1	AY339625	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-14_1	AJ555825	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-15_1	AJ555823	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-16_1	AJ781421	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-17_1	AY513266	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-18_1	AY743434	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-19_1	AB194410	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-2_1	X91840	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-20_1	AY960293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-21_1	DQ139328	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-22_1	DQ256079	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-23_1	DQ438952	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-24_1	EF415650	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-25_1	EU515249	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-26_1	AB300358	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-27_1	EU515250	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-28_1	EF561644	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-29_1	EF685371	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-30_1	LMYO01000054	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-31_1	EF622224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-32_1	EU496815	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-33_1	EU496816	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-34_1	EF394370	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-35_1	EF394371	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-36_1	EU331426	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-37_1	AB280919	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-38_1	AM931008	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-39_1	AB372224	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-4_1	LNHZ01000079	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-40_1	EU515251	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-41_1	AB429270	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-42_1	HM146927	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-43_1	FJ360626	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-44_1	FJ437066	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-45_1	FN546177	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-46_1	FN556186	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-47_1	HM046998	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-48_1	HM569226	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-49_1	GQ402541	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-5_1	Y17716	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-51_1	JQ733571	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-53_1	HQ336940	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-54_1	HM544039	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-55_1	HM544040	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-56_1	HQ322613	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-57_1	HQ285243	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-58_1	HQ185697	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-6_1	AJ011293	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-60_1	JF460794	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-61_1	JF460795	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-62_1	JF460796	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-63_1	HQ650104	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-64_1	HQ832678	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-65_1	JF780936	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-66_1	JN714478	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-67_1	JQ711185	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-68_1	JN714480	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-69_1	JX049132	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-7_1	DQ173300	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-70_1	JX440350	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-71_1	JQ711184	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-72_1	JX440352	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-73_1	GQ351345	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-74_1	JX440349	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-75_1	JQ733572	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-76_1	JQ733573	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-77_1	JX440353	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-78_1	JQ733575	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-79_1	JQ733576	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-8_1	AB201268	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-80_1	JQ733577	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-81_1	JQ733578	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-83_1	JX440351	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-84_1	JQ733579	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-87_1	AB699171	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-9_1	AB061794	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-94_1	JX514368	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-95_1	JX514369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-98_1	KC603538	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaCMY-99_1	KF305673	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-1_1	X77455	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-10_1	JX049131	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-2_1	Y10282	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-3_1	Y11068	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-4_1	AJ277535	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-5_1	AY007369	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-6_1	AY034848	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-7_1	AJ703796	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-8_1	HM565917	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaFOX-9_1	JF896803	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaLAT-1_1	X78117	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-1_1	M37839	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-2_1	AY227752	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-3_1	AY743435	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-4_1	EF417572	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-5_1	FJ237367	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMIR-6_1	JQ664733	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOR_1	Y10283	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOR-2_1	AY235804	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-1_1	D13304	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-2_1	AJ276453	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-3_1	EU515248	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-4_1	FJ262599	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-5_1	GQ152600	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-6_1	GQ152601	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaMOX-7_1	GQ152602	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-2_1	AJ295340	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-3_1	AJ295341	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-4_1	AJ295342	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-5_1	AJ295343	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-6_1	AJ295344	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-7_1	AJ295345	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaOCH-8_1	DQ489307	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaPAO_1	AY083595	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaPAO_2	FJ666065	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaPAO_3	FJ666073	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaPAO_4	AY083592	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone
-beta-lactam	blaDHA-1_1	Y16410	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaDHA-2_1	AF259520	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaDHA-3_1	AY494945	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaDHA-5_1	JF273491	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaDHA-6_1	HQ322612	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaDHA-7_1	HQ456945	ampicillin,amoxicillin/clavulanic acid,cefoxitin
-beta-lactam	blaSHV-107_1	AM922308	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaSHV-49_1	AY528718	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaSHV-56_1	EU586041	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaSHV-72_1	AM176547	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-30_1	AJ437107	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-33_1	GU371926	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-34_1	KC292503	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-45_1	X95401	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-54_1	AF104442	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-67_1	AF091113	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-76_1	AF190694	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-77_1	AF190695	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-78_1	AF190693	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-79_1	AF190692	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-80_1	AF347054	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-81_1	AF427127	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-82_1	AF427128	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-83_1	AF427129	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-84_1	AF427130	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaOXA-287_1	NG_050609	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaOXA-293_1	NG_050610	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaOXA-307_1	NG_050611	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-122_1	AY307100	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-145_1	DQ105528	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-159_1	EF136376	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-160_1	EF136377	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-182_1	HQ317449	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-185_1	JF795538	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaCARB-1_1	AF313471	ampicillin
-beta-lactam	blaCARB-2_1	M69058	ampicillin
-beta-lactam	blaCARB-3_1	S46063	ampicillin
-beta-lactam	blaCARB-4_1	FJ785525	ampicillin
-beta-lactam	blaCARB-5_1	AF135373	ampicillin
-beta-lactam	blaCARB-6_1	AF030945	ampicillin
-beta-lactam	blaCARB-7_1	AF409092	ampicillin
-beta-lactam	blaCARB-8_1	AY178993	ampicillin
-beta-lactam	blaCARB-9_1	AY248038	ampicillin
-beta-lactam	blaCARB-10_1	EU850412	ampicillin
-beta-lactam	blaCARB-11_1	AY008290	ampicillin
-beta-lactam	blaCARB-12_1	D13210	ampicillin
-beta-lactam	blaCARB-14_1	JQ364968	ampicillin
-beta-lactam	blaCARB-16_1	HF953351	ampicillin
-beta-lactam	blaCARB-17_1	KJ934265	ampicillin
-beta-lactam	blaCARB-18_1	KJ934266	ampicillin
-beta-lactam	blaCARB-19_1	KJ934267	ampicillin
-beta-lactam	blaCARB-20_1	NG_054946	ampicillin
-beta-lactam	blaCARB-21_1	NG_048724	ampicillin
-beta-lactam	blaCARB-22_1	JYNG01000059	ampicillin
-beta-lactam	blaCARB-23_1	NG_048726	ampicillin
-beta-lactam	blaCARB-24_1	BK008907	ampicillin
-beta-lactam	blaCARB-25_1	BK008888	ampicillin
-beta-lactam	blaCARB-26_1	BK008904	ampicillin
-beta-lactam	blaCARB-27_1	NG_048730	ampicillin
-beta-lactam	blaCARB-28_1	BK008906	ampicillin
-beta-lactam	blaCARB-29_1	BK008905	ampicillin
-beta-lactam	blaCARB-30_1	NG_048734	ampicillin
-beta-lactam	blaCARB-31_1	NG_048735	ampicillin
-beta-lactam	blaCARB-32_1	NG_048736	ampicillin
-beta-lactam	blaCARB-33_1	BK008903	ampicillin
-beta-lactam	blaCARB-34_1	NG_048738	ampicillin
-beta-lactam	blaCARB-35_1	BK008900	ampicillin
-beta-lactam	blaCARB-36_1	LHBD01000022	ampicillin
-beta-lactam	blaCARB-38_1	BK008898	ampicillin
-beta-lactam	blaCARB-40_1	BK008889	ampicillin
-beta-lactam	blaCARB-41_1	BK008890	ampicillin
-beta-lactam	blaCARB-42_1	NG_048745	ampicillin
-beta-lactam	blaCARB-43_1	NG_048746	ampicillin
-beta-lactam	blaCARB-44_1	JTGS01000066	ampicillin
-beta-lactam	blaCARB-45_1	JTGR01000061	ampicillin
-beta-lactam	blaCARB-46_1	NG_048749	ampicillin
-beta-lactam	blaCARB-47_1	NG050564	ampicillin
-beta-lactam	blaCARB-48_1	NG050604	ampicillin
-beta-lactam	blaCARB-49_1	KX599396	ampicillin
-beta-lactam	blaCARB-50_1	NG_052478	ampicillin
-beta-lactam	blaFRI-1_1	KT192551	ampicillin,meropenem
-beta-lactam	blaFRI-2_1	KX620467	ampicillin,meropenem
-beta-lactam	blaFRI-3_1	KY524440	ampicillin,meropenem
-beta-lactam	blaFRI-4_1	NG_055267	ampicillin,meropenem
-beta-lactam	blaFRI-5_1	MH208723	ampicillin,meropenem
-beta-lactam	blaCMH-3_1	KX192165	ampicillin
-beta-lactam	blaL_1	NG050597	ampicillin
-beta-lactam	blaL_2	NG050596	ampicillin
-beta-lactam	blaOXA-298_1	APSA01000003	ampicillin
-beta-lactam	blaOXA-299_1	APQD01000016	ampicillin
-beta-lactam	blaOXA-302_1	APRT01000004	ampicillin
-beta-lactam	blaOXA-303_1	APSD01000035	ampicillin
-beta-lactam	blaOXA-306_1	APSB01000022	ampicillin
-beta-lactam	blaOXA-308_1	APPN01000080	ampicillin
-beta-lactam	blaOXA-446_1	KR061495	ampicillin
-beta-lactam	blaOXA-447_1	KR061496	ampicillin
-beta-lactam	blaOXA-448_1	KR061497	ampicillin
-beta-lactam	blaOXA-449_1	KR061498	ampicillin
-beta-lactam	blaOXA-464_1	KU721146	ampicillin
-beta-lactam	blaOXA-465_1	KR061500	ampicillin
-beta-lactam	blaOXA-466_1	KR061501	ampicillin
-beta-lactam	blaOXA-491_1	KU721148	ampicillin
-beta-lactam	blaOXA-493_1	CP007774	ampicillin
-beta-lactam	blaOXA-493_1	KU739135	ampicillin
-beta-lactam	blaOXA-518_1	KU739134	ampicillin
-beta-lactam	blaPLA1a_1	AY302757	ampicillin
-beta-lactam	blaPLA2a_1	AY307385	ampicillin
-beta-lactam	blaPLA-3A_1	AY507663	ampicillin
-beta-lactam	blaPLA-4A_1	AY507664	ampicillin
-beta-lactam	blaPLA-5A_1	DQ249871	ampicillin
-beta-lactam	blaPLA-6A_1	DQ251478	ampicillin
-beta-lactam	blaSCO-1_1	EF063111	ampicillin
-beta-lactam	blaSGM-1_1	AAQG01000013	ampicillin
-beta-lactam	blaSGM-2_1	AP010803	ampicillin
-beta-lactam	blaSGM-4_1	CP002798	ampicillin
-beta-lactam	blaSGM-5_1	NG049987	ampicillin
-beta-lactam	blaSGM-6_1	NG049988	ampicillin
-beta-lactam	blaSGM-7_1	NG050614	ampicillin
-beta-lactam	blaTER-1_1	FJ263091	ampicillin
-beta-lactam	blaTER-2_1	FJ263090	ampicillin
-beta-lactam	blaVHH-1_1	NG050334	ampicillin
-beta-lactam	blaVHW-1_1	AF217648	ampicillin
-beta-lactam	cepA_1	L13472	ampicillin
-beta-lactam	cepA_1	U05887	ampicillin
-beta-lactam	cepA_6	FR688022	ampicillin
-beta-lactam	cepA-29_1	U05884	ampicillin
-beta-lactam	cepA-44_1	U05885	ampicillin
-beta-lactam	cepA-49_1	U05886	ampicillin
-beta-lactam	ampH_1	AJ276031	ampicillin
-beta-lactam	ampH_2	HQ586946	ampicillin
-beta-lactam	ampS_1	X80276	ampicillin
-beta-lactam	blaA_1	DQ424965	ampicillin
-beta-lactam	blaA_2	AY954728	ampicillin
-beta-lactam	blaACI-1_1	AJ007350	ampicillin
-beta-lactam	blaADC-25_1	EF016355	ampicillin
-beta-lactam	blaAER-1_1	U14748	ampicillin
-beta-lactam	blaAST-1_1	AF279904	ampicillin
-beta-lactam	blaBES-1_1	AF234999	ampicillin
-beta-lactam	blaBIC-1_1	GQ260093	ampicillin
-beta-lactam	blaBIL-1_1	X74512	ampicillin
-beta-lactam	blaBRO-1_1	Z54180	ampicillin
-beta-lactam	blaBRO-2_1	Z54181	ampicillin
-beta-lactam	blaCEPH-A3_1	AY112998	ampicillin
-beta-lactam	blaCGB-1_1	EF672680	ampicillin
-beta-lactam	blaCKO-1_1	AF477396	ampicillin
-beta-lactam	blaCME-1_1	AJ006275	ampicillin
-beta-lactam	blaCMG_1	AY265892	ampicillin
-beta-lactam	blaDES-1_1	AF426161	ampicillin
-beta-lactam	blaDIM-1_1	GU323019	ampicillin
-beta-lactam	blaEBR-1_1	AF416700	ampicillin
-beta-lactam	blaERP-1_1	AY077733	ampicillin
-beta-lactam	blaFAR-1_1	AF024601	ampicillin
-beta-lactam	blaFONA-1_1	AJ251239	ampicillin
-beta-lactam	blaFONA-2_1	AJ251240	ampicillin
-beta-lactam	blaFONA-3_1	AJ251241	ampicillin
-beta-lactam	blaFONA-4_1	AJ251242	ampicillin
-beta-lactam	blaFONA-5_1	AJ251243	ampicillin
-beta-lactam	blaFONA-6_1	AJ251244	ampicillin
-beta-lactam	blaGIM-1_1	JF414726	ampicillin
-beta-lactam	blaHERA-1_1	AF311385	ampicillin
-beta-lactam	blaHERA-2_1	AF398334	ampicillin
-beta-lactam	blaHERA-3_1	AF398335	ampicillin
-beta-lactam	blaHERA-4_1	AJ536088	ampicillin
-beta-lactam	blaHERA-5_1	AJ536089	ampicillin
-beta-lactam	blaHERA-6_1	AJ536090	ampicillin
-beta-lactam	blaHERA-8_1	AJ536092	ampicillin
-beta-lactam	blaJOHN-1_1	AY028464	ampicillin
-beta-lactam	blaKHM-1_1	AB364006	ampicillin
-beta-lactam	blaL1_3	EF126059	ampicillin
-beta-lactam	blaLCR-1_1	X56809	ampicillin
-beta-lactam	blaLEN1_1	X04515	ampicillin
-beta-lactam	blaLEN10_1	AJ635419	ampicillin
-beta-lactam	blaLEN12_1	AJ635406	ampicillin
-beta-lactam	blaLEN13_1	AJ635403	ampicillin
-beta-lactam	blaLEN15_1	AF452105	ampicillin
-beta-lactam	blaLEN16_1	AY743416	ampicillin
-beta-lactam	blaLEN17_1	EF205593	ampicillin
-beta-lactam	blaLEN18_1	AM850908	ampicillin
-beta-lactam	blaLEN19_1	AM850909	ampicillin
-beta-lactam	blaLEN2_1	AY037780	ampicillin
-beta-lactam	blaLEN20_1	AM850910	ampicillin
-beta-lactam	blaLEN21_1	AM850911	ampicillin
-beta-lactam	blaLEN22_1	AM850912	ampicillin
-beta-lactam	blaLEN23_1	AM850913	ampicillin
-beta-lactam	blaLEN24_1	AM850914	ampicillin
-beta-lactam	blaLEN25_1	HQ709169	ampicillin
-beta-lactam	blaLEN26_1	JQ067123	ampicillin
-beta-lactam	blaLEN3_1	AY130286	ampicillin
-beta-lactam	blaLEN4_1	AY130287	ampicillin
-beta-lactam	blaLEN5_1	AY633109	ampicillin
-beta-lactam	blaLEN7_1	AJ635425	ampicillin
-beta-lactam	blaLEN8_1	AJ635424	ampicillin
-beta-lactam	blaLEN9_1	AJ635405	ampicillin
-beta-lactam	blaLUT-1_1	AY695112	ampicillin
-beta-lactam	blaMAL-1_1	AJ277209	ampicillin
-beta-lactam	blaMAL-1_2	AJ609506	ampicillin
-beta-lactam	blaMUS-1_1	AF441286	ampicillin
-beta-lactam	blaNMC-A_1	AJ536087	ampicillin
-beta-lactam	blaNPS_1	AY027589	ampicillin
-beta-lactam	blaOKP-A-1_1	AM051138	ampicillin
-beta-lactam	blaOKP-A-10_1	AM051149	ampicillin
-beta-lactam	blaOKP-A-11_1	AM850915	ampicillin
-beta-lactam	blaOKP-A-12_1	AM850915	ampicillin
-beta-lactam	blaOKP-A-13_1	FJ534513	ampicillin
-beta-lactam	blaOKP-A-14_1	FJ534512	ampicillin
-beta-lactam	blaOKP-A-15_1	FJ755841	ampicillin
-beta-lactam	blaOKP-A-16_1	FJ755840	ampicillin
-beta-lactam	blaOKP-A-2_1	AM051139	ampicillin
-beta-lactam	blaOKP-A-3_1	AM051140	ampicillin
-beta-lactam	blaOKP-A-4_1	AM051142	ampicillin
-beta-lactam	blaOKP-A-5_1	AM051143	ampicillin
-beta-lactam	blaOKP-A-6_1	AM051144	ampicillin
-beta-lactam	blaOKP-A-7_1	AM051145	ampicillin
-beta-lactam	blaOKP-A-8_1	AM051147	ampicillin
-beta-lactam	blaOKP-A-9_1	AM051148	ampicillin
-beta-lactam	blaOKP-B-1_1	AM051150	ampicillin
-beta-lactam	blaOKP-B-10_1	AM051160	ampicillin
-beta-lactam	blaOKP-B-11_1	AM051161	ampicillin
-beta-lactam	blaOKP-B-12_1	AJ635420	ampicillin
-beta-lactam	blaOKP-B-13_1	AY825330	ampicillin
-beta-lactam	blaOKP-B-14_1	DQ995288	ampicillin
-beta-lactam	blaOKP-B-15_1	AM850917	ampicillin
-beta-lactam	blaOKP-B-16_1	AM850918	ampicillin
-beta-lactam	blaOKP-B-17_1	AM850919	ampicillin
-beta-lactam	blaOKP-B-18_1	AM850920	ampicillin
-beta-lactam	blaOKP-B-19_1	AM850921	ampicillin
-beta-lactam	blaOKP-B-2_1	AM051151	ampicillin
-beta-lactam	blaOKP-B-20_1	AM850922	ampicillin
-beta-lactam	blaOKP-B-3_1	AM051152	ampicillin
-beta-lactam	blaOKP-B-4_1	AM051153	ampicillin
-beta-lactam	blaOKP-B-5_1	AY512506	ampicillin
-beta-lactam	blaOKP-B-6_1	AY850171	ampicillin
-beta-lactam	blaOKP-B-7_1	AM051156	ampicillin
-beta-lactam	blaOKP-B-8_1	AM051157	ampicillin
-beta-lactam	blaOKP-B-9_1	AM051159	ampicillin
-beta-lactam	blaOXA-1_1	HQ170510	ampicillin
-beta-lactam	blaOXA-10_1	J03427	ampicillin
-beta-lactam	blaOXA-100_1	AM231720	ampicillin
-beta-lactam	blaOXA-101_1	AM412777	ampicillin
-beta-lactam	blaOXA-104_1	EF581285	ampicillin
-beta-lactam	blaOXA-106_1	EF650032	ampicillin
-beta-lactam	blaOXA-107_1	LAVJ01000082	ampicillin
-beta-lactam	blaOXA-108_1	EF650034	ampicillin
-beta-lactam	blaOXA-109_1	EF650035	ampicillin
-beta-lactam	blaOXA-110_1	EF650036	ampicillin
-beta-lactam	blaOXA-111_1	EF650037	ampicillin
-beta-lactam	blaOXA-112_1	EF650038	ampicillin
-beta-lactam	blaOXA-113_1	EF653400	ampicillin
-beta-lactam	blaOXA-115_1	EU029998	ampicillin
-beta-lactam	blaOXA-116_1	EU220744	ampicillin
-beta-lactam	blaOXA-117_1	GQ423625	ampicillin
-beta-lactam	blaOXA-118_1	AF371964	ampicillin
-beta-lactam	blaOXA-119_1	DQ767903	ampicillin
-beta-lactam	blaOXA-120_1	EU255289	ampicillin
-beta-lactam	blaOXA-128_1	EU375515	ampicillin
-beta-lactam	blaOXA-129_1	FJWZ01000025	ampicillin
-beta-lactam	blaOXA-13_1	AF043558	ampicillin
-beta-lactam	blaOXA-13_1	U59183	ampicillin
-beta-lactam	blaOXA-130_1	EU547445	ampicillin
-beta-lactam	blaOXA-131_1	EU547446	ampicillin
-beta-lactam	blaOXA-132_1	EU547447	ampicillin
-beta-lactam	blaOXA-133_1	EU571228	ampicillin
-beta-lactam	blaOXA-134_1	HQ122933	ampicillin
-beta-lactam	blaOXA-136_1	EU086831	ampicillin
-beta-lactam	blaOXA-137_1	EU086834	ampicillin
-beta-lactam	blaOXA-138_1	EU670845	ampicillin
-beta-lactam	blaOXA-139_1	AM991978	ampicillin
-beta-lactam	blaOXA-143_1	GQ861437	ampicillin
-beta-lactam	blaOXA-144_1	FJ872530	ampicillin
-beta-lactam	blaOXA-146_1	FJ194494	ampicillin
-beta-lactam	blaOXA-148_1	GQ853679	ampicillin
-beta-lactam	blaOXA-149_1	GQ853680	ampicillin
-beta-lactam	blaOXA-150_1	GQ853681	ampicillin
-beta-lactam	blaOXA-160_1	GU199038	ampicillin
-beta-lactam	blaOXA-162_1	GU197550	ampicillin
-beta-lactam	blaOXA-163_1	HQ700343	ampicillin
-beta-lactam	blaOXA-164_1	GU831575	ampicillin
-beta-lactam	blaOXA-165_1	HM488986	ampicillin
-beta-lactam	blaOXA-166_1	HM488987	ampicillin
-beta-lactam	blaOXA-167_1	HM488988	ampicillin
-beta-lactam	blaOXA-168_1	HM488989	ampicillin
-beta-lactam	blaOXA-169_1	HM488990	ampicillin
-beta-lactam	blaOXA-170_1	HM488991	ampicillin
-beta-lactam	blaOXA-171_1	HM488992	ampicillin
-beta-lactam	blaOXA-172_1	HM113558	ampicillin
-beta-lactam	blaOXA-173_1	HM113559	ampicillin
-beta-lactam	blaOXA-174_1	HM113560	ampicillin
-beta-lactam	blaOXA-175_1	HM113561	ampicillin
-beta-lactam	blaOXA-176_1	HM113562	ampicillin
-beta-lactam	blaOXA-177_1	HM113563	ampicillin
-beta-lactam	blaOXA-178_1	HM113564	ampicillin
-beta-lactam	blaOXA-179_1	HM570035	ampicillin
-beta-lactam	blaOXA-18_1	U85514	ampicillin
-beta-lactam	blaOXA-180_1	HM570036	ampicillin
-beta-lactam	blaOXA-181_1	CM004561	ampicillin
-beta-lactam	blaOXA-182_1	HM640278	ampicillin
-beta-lactam	blaOXA-183_1	HQ111474	ampicillin
-beta-lactam	blaOXA-192_1	JF273470	ampicillin
-beta-lactam	blaOXA-194_1	HQ425492	ampicillin
-beta-lactam	blaOXA-195_1	HQ425493	ampicillin
-beta-lactam	blaOXA-196_1	HQ425494	ampicillin
-beta-lactam	blaOXA-197_1	HQ425495	ampicillin
-beta-lactam	blaOXA-198_1	HQ634775	ampicillin
-beta-lactam	blaOXA-199_1	JN704570	ampicillin
-beta-lactam	blaOXA-2_1	DQ112222	ampicillin
-beta-lactam	blaOXA-2_2	GQ466184	ampicillin
-beta-lactam	blaOXA-20_1	AY307114	ampicillin
-beta-lactam	blaOXA-200_1	HQ734811	ampicillin
-beta-lactam	blaOXA-201_1	HQ734812	ampicillin
-beta-lactam	blaOXA-202_1	HQ734813	ampicillin
-beta-lactam	blaOXA-203_1	HQ998857	ampicillin
-beta-lactam	blaOXA-204_1	KP027885	ampicillin
-beta-lactam	blaOXA-205_1	JF800667	ampicillin
-beta-lactam	blaOXA-206_1	AB634250	ampicillin
-beta-lactam	blaOXA-207_1	LLFS01000355	ampicillin
-beta-lactam	blaOXA-208_1	KF305665	ampicillin
-beta-lactam	blaOXA-209_1	JF268688	ampicillin
-beta-lactam	blaOXA-210_1	JF795487	ampicillin
-beta-lactam	blaOXA-211_1	JN861779	ampicillin
-beta-lactam	blaOXA-212_1	JN861780	ampicillin
-beta-lactam	blaOXA-213_1	JN861781	ampicillin
-beta-lactam	blaOXA-214_1	JN861782	ampicillin
-beta-lactam	blaOXA-215_1	JN861783	ampicillin
-beta-lactam	blaOXA-216_1	FR865168	ampicillin
-beta-lactam	blaOXA-217_1	JN603240	ampicillin
-beta-lactam	blaOXA-219_1	JN215211	ampicillin
-beta-lactam	blaOXA-22_1	AF064820	ampicillin
-beta-lactam	blaOXA-223_1	JN248564	ampicillin
-beta-lactam	blaOXA-224_1	JN412067	ampicillin
-beta-lactam	blaOXA-225_1	JN638887	ampicillin
-beta-lactam	blaOXA-228_1	JQ422053	ampicillin
-beta-lactam	blaOXA-229_1	JQ422052	ampicillin
-beta-lactam	blaOXA-230_1	JQ422054	ampicillin
-beta-lactam	blaOXA-231_1	JQ326200	ampicillin
-beta-lactam	blaOXA-232_1	JX423831	ampicillin
-beta-lactam	blaOXA-235_1	JQ820240	ampicillin
-beta-lactam	blaOXA-236_1	JQ820242	ampicillin
-beta-lactam	blaOXA-237_1	JQ820241	ampicillin
-beta-lactam	blaOXA-239_1	JQ837239	ampicillin
-beta-lactam	blaOXA-240_1	JX089628	ampicillin
-beta-lactam	blaOXA-241_1	JX025021	ampicillin
-beta-lactam	blaOXA-242_1	JX025022	ampicillin
-beta-lactam	blaOXA-243_1	AFRQ01000031	ampicillin
-beta-lactam	blaOXA-244_1	KP659189	ampicillin,amoxicillin/clavulanic acid,ds-meropenem
-beta-lactam	blaOXA-245_1	JX438001	ampicillin
-beta-lactam	blaOXA-247_1	JX893517	ampicillin
-beta-lactam	blaOXA-248_1	HE963769	ampicillin
-beta-lactam	blaOXA-249_1	HE963770	ampicillin
-beta-lactam	blaOXA-25_1	AF201826	ampicillin
-beta-lactam	blaOXA-250_1	HE963771	ampicillin
-beta-lactam	blaOXA-251_1	JN118546	ampicillin
-beta-lactam	blaOXA-253_1	KC479324	ampicillin
-beta-lactam	blaOXA-254_1	AB781687	ampicillin
-beta-lactam	blaOXA-255_1	KC479325	ampicillin
-beta-lactam	blaOXA-256_1	HE616889	ampicillin
-beta-lactam	blaOXA-257_1	KC567681	ampicillin
-beta-lactam	blaOXA-258_1	HE614014	ampicillin
-beta-lactam	blaOXA-26_1	AF201827	ampicillin
-beta-lactam	blaOXA-27_1	AF201828	ampicillin
-beta-lactam	blaOXA-278_1	KC771279	ampicillin
-beta-lactam	blaOXA-29_1	AJ400619	ampicillin
-beta-lactam	blaOXA-3_1	L07945	ampicillin
-beta-lactam	blaOXA-309_1	HF947514	ampicillin
-beta-lactam	blaOXA-31_1	AF294653	ampicillin
-beta-lactam	blaOXA-320_1	KF151169	ampicillin
-beta-lactam	blaOXA-322_1	KF203096	ampicillin
-beta-lactam	blaOXA-323_1	KF203097	ampicillin
-beta-lactam	blaOXA-324_1	KF203098	ampicillin
-beta-lactam	blaOXA-325_1	KF203099	ampicillin
-beta-lactam	blaOXA-326_1	KF203100	ampicillin
-beta-lactam	blaOXA-327_1	KF203101	ampicillin
-beta-lactam	blaOXA-328_1	KF203102	ampicillin
-beta-lactam	blaOXA-329_1	KF203103	ampicillin
-beta-lactam	blaOXA-330_1	KF203104	ampicillin
-beta-lactam	blaOXA-331_1	KF203105	ampicillin
-beta-lactam	blaOXA-332_1	KF203106	ampicillin
-beta-lactam	blaOXA-333_1	KF203107	ampicillin
-beta-lactam	blaOXA-334_1	KF203108	ampicillin
-beta-lactam	blaOXA-335_1	KF203109	ampicillin
-beta-lactam	blaOXA-34_1	AF350424	ampicillin
-beta-lactam	blaOXA-347_1	ACWG01000053	ampicillin
-beta-lactam	blaOXA-347_1	JN086160	ampicillin
-beta-lactam	blaOXA-348_1	KF297577	ampicillin
-beta-lactam	blaOXA-349_1	KF297578	ampicillin
-beta-lactam	blaOXA-350_1	KF297579	ampicillin
-beta-lactam	blaOXA-351_1	KF297580	ampicillin
-beta-lactam	blaOXA-352_1	KF297581	ampicillin
-beta-lactam	blaOXA-353_1	KF297582	ampicillin
-beta-lactam	blaOXA-354_1	KF297583	ampicillin
-beta-lactam	blaOXA-355_1	KF297584	ampicillin
-beta-lactam	blaOXA-356_1	KF297585	ampicillin
-beta-lactam	blaOXA-357_1	KF421160	ampicillin
-beta-lactam	blaOXA-358_1	KF421161	ampicillin
-beta-lactam	blaOXA-359_1	KF421162	ampicillin
-beta-lactam	blaOXA-360_1	KF421163	ampicillin
-beta-lactam	blaOXA-371_1	AB871653	ampicillin
-beta-lactam	blaOXA-372_1	KJ746496	ampicillin
-beta-lactam	blaOXA-4_1	AY162283	ampicillin
-beta-lactam	blaOXA-42_1	AJ488302	ampicillin
-beta-lactam	blaOXA-43_1	AJ488303	ampicillin
-beta-lactam	blaOXA-436_1	KT959105	ampicillin
-beta-lactam	blaOXA-45_1	AJ519683	ampicillin
-beta-lactam	blaOXA-46_1	AF317511	ampicillin
-beta-lactam	blaOXA-47_1	AY237830	ampicillin
-beta-lactam	blaOXA-49_1	AY288523	ampicillin
-beta-lactam	blaOXA-5_1	AF347074	ampicillin
-beta-lactam	blaOXA-50_1	AY306130	ampicillin
-beta-lactam	blaOXA-53_1	AY289608	ampicillin
-beta-lactam	blaOXA-54_1	AY500137	ampicillin
-beta-lactam	blaOXA-55_1	AY343493	ampicillin
-beta-lactam	blaOXA-56_1	AY445080	ampicillin
-beta-lactam	blaOXA-57_1	AJ631966	ampicillin
-beta-lactam	blaOXA-59_1	AJ632249	ampicillin
-beta-lactam	blaOXA-60_1	AF525303	ampicillin
-beta-lactam	blaOXA-61_1	AY587956	ampicillin
-beta-lactam	blaOXA-62_1	AY423074	ampicillin
-beta-lactam	blaOXA-63_1	AY619003	ampicillin
-beta-lactam	blaOXA-64_1	AY750907	ampicillin
-beta-lactam	blaOXA-65_1	AY750908	ampicillin
-beta-lactam	blaOXA-67_1	DQ491200	ampicillin
-beta-lactam	blaOXA-68_1	AY750910	ampicillin
-beta-lactam	blaOXA-69_1	AY859527	ampicillin
-beta-lactam	blaOXA-7_1	X75562	ampicillin
-beta-lactam	blaOXA-70_1	AY750912	ampicillin
-beta-lactam	blaOXA-71_1	AY750913	ampicillin
-beta-lactam	blaOXA-72_1	AY739646	ampicillin
-beta-lactam	blaOXA-73_1	AY762325	ampicillin
-beta-lactam	blaOXA-74_1	EU161636	ampicillin
-beta-lactam	blaOXA-75_1	AY859529	ampicillin
-beta-lactam	blaOXA-76_1	AY949203	ampicillin
-beta-lactam	blaOXA-77_1	AY949202	ampicillin
-beta-lactam	blaOXA-78_1	AY862132	ampicillin
-beta-lactam	blaOXA-79_1	EU019534	ampicillin
-beta-lactam	blaOXA-80_1	EU019535	ampicillin
-beta-lactam	blaOXA-82_1	DQ987479	ampicillin
-beta-lactam	blaOXA-83_1	DQ309277	ampicillin
-beta-lactam	blaOXA-84_1	DQ309276	ampicillin
-beta-lactam	blaOXA-85_1	JANA01000064	ampicillin
-beta-lactam	blaOXA-86_1	DQ149247	ampicillin
-beta-lactam	blaOXA-87_1	DQ348075	ampicillin
-beta-lactam	blaOXA-88_1	DQ392963	ampicillin
-beta-lactam	blaOXA-90_1	EU547443	ampicillin
-beta-lactam	blaOXA-91_1	DQ519086	ampicillin
-beta-lactam	blaOXA-92_1	DQ335566	ampicillin
-beta-lactam	blaOXA-93_1	DQ519087	ampicillin
-beta-lactam	blaOXA-94_1	DQ519088	ampicillin
-beta-lactam	blaOXA-95_1	DQ519089	ampicillin
-beta-lactam	blaOXA-96_1	DQ519090	ampicillin
-beta-lactam	blaOXA-97_1	EF102240	ampicillin
-beta-lactam	blaOXA-98_1	EU255288	ampicillin
-beta-lactam	blaOXA-99_1	DQ888718	ampicillin
-beta-lactam	blaOXA-SHE_1	AY066004	ampicillin
-beta-lactam	blaOXY-1-1_1	Z30177	ampicillin
-beta-lactam	blaOXY-1-2_2	AJ871864	ampicillin
-beta-lactam	blaOXY-1-3_3	AY077482	ampicillin
-beta-lactam	blaOXY-1-4_4	AY077483	ampicillin
-beta-lactam	blaOXY-1-5_5	AY077486	ampicillin
-beta-lactam	blaOXY-1-6_6	Y17715	ampicillin
-beta-lactam	blaOXY-1-7_7	M27459	ampicillin
-beta-lactam	blaOXY-2-1_1	AJ871866	ampicillin
-beta-lactam	blaOXY-2-10_10	FJ785626	ampicillin
-beta-lactam	blaOXY-2-2_2	AJ871867	ampicillin
-beta-lactam	blaOXY-2-3_3	AY077488	ampicillin
-beta-lactam	blaOXY-2-4_4	Y17714	ampicillin
-beta-lactam	blaOXY-2-5_5	AY077487	ampicillin
-beta-lactam	blaOXY-2-6_6	AY077485	ampicillin
-beta-lactam	blaOXY-2-7_7	Z49084	ampicillin
-beta-lactam	blaOXY-2-8_8	AY055205	ampicillin
-beta-lactam	blaOXY-2-9_9	FJ785625	ampicillin
-beta-lactam	blaOXY-3-1_1	AF491278	ampicillin
-beta-lactam	blaOXY-4-1_1	AY077481	ampicillin
-beta-lactam	blaOXY-5-1_1	AJ871868	ampicillin
-beta-lactam	blaOXY-5-2_2	AJ871871	ampicillin
-beta-lactam	blaOXY-6-1_1	AJ871873	ampicillin
-beta-lactam	blaOXY-6-2_2	AJ871875	ampicillin
-beta-lactam	blaOXY-6-3_3	AJ871876	ampicillin
-beta-lactam	blaOXY-6-4_4	AJ871877	ampicillin
-beta-lactam	blaPME-1_1	HQ541434	ampicillin
-beta-lactam	blaROB-1_1	DQ840517	ampicillin
-beta-lactam	blaROB-1_2	AF022114	ampicillin
-beta-lactam	blaSED1_1	AF321608	ampicillin
-beta-lactam	blaSFO-1_1	AB003148	ampicillin
-beta-lactam	blaSHV-1_1	AF148850	ampicillin
-beta-lactam	blaSHV-101_1	EU155018	ampicillin
-beta-lactam	blaSHV-103_1	EU032604	ampicillin
-beta-lactam	blaSHV-106_1	AM922307	ampicillin
-beta-lactam	blaSHV-108_1	AM922309	ampicillin
-beta-lactam	blaSHV-109_1	EU418913	ampicillin
-beta-lactam	blaSHV-11_1	X98101	ampicillin
-beta-lactam	blaSHV-110_1	HQ877615	ampicillin
-beta-lactam	blaSHV-120_1	JF812965	ampicillin
-beta-lactam	blaSHV-121_1	GQ428198	ampicillin
-beta-lactam	blaSHV-128_1	GU932590	ampicillin
-beta-lactam	blaSHV-129_1	GU827715	ampicillin
-beta-lactam	blaSHV-132_1	GU981741	ampicillin
-beta-lactam	blaSHV-133_1	AB551737	ampicillin
-beta-lactam	blaSHV-135_1	HQ637576	ampicillin
-beta-lactam	blaSHV-137_1	HQ661363	ampicillin
-beta-lactam	blaSHV-14_1	AF226622	ampicillin
-beta-lactam	blaSHV-141_1	JQ388884	ampicillin
-beta-lactam	blaSHV-142_1	JQ029959	ampicillin
-beta-lactam	blaSHV-143_1	JQ341060	ampicillin
-beta-lactam	blaSHV-144_1	JQ926986	ampicillin
-beta-lactam	blaSHV-145_1	JX013655	ampicillin
-beta-lactam	blaSHV-147_1	JX121114	ampicillin
-beta-lactam	blaSHV-148_1	JX121115	ampicillin
-beta-lactam	blaSHV-149_1	JX121116	ampicillin
-beta-lactam	blaSHV-150_1	JX121117	ampicillin
-beta-lactam	blaSHV-151_1	JX121118	ampicillin
-beta-lactam	blaSHV-152_1	JX121119	ampicillin
-beta-lactam	blaSHV-153_1	JX121120	ampicillin
-beta-lactam	blaSHV-154_1	JX121121	ampicillin
-beta-lactam	blaSHV-155_1	JX121122	ampicillin
-beta-lactam	blaSHV-156_1	JX121123	ampicillin
-beta-lactam	blaSHV-157_1	JX121124	ampicillin
-beta-lactam	blaSHV-158_1	JX121125	ampicillin
-beta-lactam	blaSHV-159_1	JX121126	ampicillin
-beta-lactam	blaSHV-160_1	JX121127	ampicillin
-beta-lactam	blaSHV-161_1	JX121128	ampicillin
-beta-lactam	blaSHV-162_1	JX121129	ampicillin
-beta-lactam	blaSHV-163_1	JX121130	ampicillin
-beta-lactam	blaSHV-164_1	HE981194	ampicillin
-beta-lactam	blaSHV-165_1	JX121131	ampicillin
-beta-lactam	blaSHV-168_1	JX870080	ampicillin
-beta-lactam	blaSHV-172_1	KF513177	ampicillin
-beta-lactam	blaSHV-173_1	KF513178	ampicillin
-beta-lactam	blaSHV-178_1	KF705209	ampicillin
-beta-lactam	blaSHV-179_1	KF705208	ampicillin
-beta-lactam	blaSHV-25_1	AF208796	ampicillin
-beta-lactam	blaSHV-26_1	AF227204	ampicillin
-beta-lactam	blaSHV-27_1	AF293345	ampicillin
-beta-lactam	blaSHV-28_1	AF299299	ampicillin
-beta-lactam	blaSHV-29_1	AF301532	ampicillin
-beta-lactam	blaSHV-33_1	AY037779	ampicillin
-beta-lactam	blaSHV-34_1	AY036620	ampicillin
-beta-lactam	blaSHV-35_1	AY070258	ampicillin
-beta-lactam	blaSHV-36_1	AF467947	ampicillin
-beta-lactam	blaSHV-37_1	AF467948	ampicillin
-beta-lactam	blaSHV-43_1	AY065991	ampicillin
-beta-lactam	blaSHV-44_1	AY259119	ampicillin
-beta-lactam	blaSHV-48_1	AY263404	ampicillin
-beta-lactam	blaSHV-50_1	AY288915	ampicillin
-beta-lactam	blaSHV-51_1	AY289548	ampicillin
-beta-lactam	blaSHV-52_1	HQ845196	ampicillin
-beta-lactam	blaSHV-59_1	AY790341	ampicillin
-beta-lactam	blaSHV-60_1	AB302939	ampicillin
-beta-lactam	blaSHV-61_1	AJ866284	ampicillin
-beta-lactam	blaSHV-62_1	AJ866285	ampicillin
-beta-lactam	blaSHV-63_1	EU342351	ampicillin
-beta-lactam	blaSHV-65_1	DQ174305	ampicillin
-beta-lactam	blaSHV-67_1	DQ174307	ampicillin
-beta-lactam	blaSHV-69_1	DQ174308	ampicillin
-beta-lactam	blaSHV-71_1	AM176546	ampicillin
-beta-lactam	blaSHV-73_1	AM176548	ampicillin
-beta-lactam	blaSHV-74_1	AM176549	ampicillin
-beta-lactam	blaSHV-75_1	AM176550	ampicillin
-beta-lactam	blaSHV-76_1	AM176551	ampicillin
-beta-lactam	blaSHV-77_1	EF373975	ampicillin
-beta-lactam	blaSHV-78_1	AM176553	ampicillin
-beta-lactam	blaSHV-79_1	AM176554	ampicillin
-beta-lactam	blaSHV-80_1	AM176555	ampicillin
-beta-lactam	blaSHV-81_1	AM176556	ampicillin
-beta-lactam	blaSHV-82_1	AM176557	ampicillin
-beta-lactam	blaSHV-85_1	DQ322460	ampicillin
-beta-lactam	blaSHV-89_1	DQ193536	ampicillin
-beta-lactam	blaSHV-92_1	DQ836922	ampicillin
-beta-lactam	blaSHV-93_1	EF373969	ampicillin
-beta-lactam	blaSHV-94_1	EF373970	ampicillin
-beta-lactam	blaSHV-95_1	EF373972	ampicillin
-beta-lactam	blaSHV-96_1	EF373971	ampicillin
-beta-lactam	blaSHV-97_1	EF373973	ampicillin
-beta-lactam	blaSIM-1_1	JF731030	ampicillin
-beta-lactam	blaSPM-1_1	AY341249	ampicillin
-beta-lactam	blaTEM-104_1	AF516719	ampicillin
-beta-lactam	blaTEM-105_1	AF516720	ampicillin
-beta-lactam	blaTEM-108_1	AF506748	ampicillin
-beta-lactam	blaTEM-110_1	AY072920	ampicillin
-beta-lactam	blaTEM-111_1	AF468003	ampicillin
-beta-lactam	blaTEM-127_1	AY368236	ampicillin
-beta-lactam	blaTEM-128_1	AY368237	ampicillin
-beta-lactam	blaTEM-135_1	GQ896333	ampicillin
-beta-lactam	blaTEM-141_1	AY956335	ampicillin
-beta-lactam	blaTEM-142_1	DQ388882	ampicillin
-beta-lactam	blaTEM-146_1	DQ105529	ampicillin
-beta-lactam	blaTEM-148_1	AM087454	ampicillin
-beta-lactam	blaTEM-150_1	AM183304	ampicillin
-beta-lactam	blaTEM-156_1	AM941159	ampicillin
-beta-lactam	blaTEM-158_1	EF534736	ampicillin
-beta-lactam	blaTEM-162_1	EF468463	ampicillin
-beta-lactam	blaTEM-163_1	EU815939	ampicillin
-beta-lactam	blaTEM-166_1	FJ197316	ampicillin
-beta-lactam	blaTEM-167_1	FJ360884	ampicillin
-beta-lactam	blaTEM-168_1	FJ919776	ampicillin
-beta-lactam	blaTEM-171_1	GQ149347	ampicillin
-beta-lactam	blaTEM-176_1	GU550123	ampicillin,amoxicillin/clavulanic acid
-beta-lactam	blaTEM-183_1	HQ529916	ampicillin
-beta-lactam	blaTEM-186_1	JN227084	ampicillin
-beta-lactam	blaTEM-189_1	JN254627	ampicillin
-beta-lactam	blaTEM-190_1	JN416112	ampicillin
-beta-lactam	blaTEM-193_1	JN935135	ampicillin
-beta-lactam	blaTEM-194_1	JN935136	ampicillin
-beta-lactam	blaTEM-195_1	JN935137	ampicillin
-beta-lactam	blaTEM-198_1	AB700703	ampicillin
-beta-lactam	blaTEM-1B_1	AY458016	ampicillin
-beta-lactam	blaTEM-2_1	X54606	ampicillin
-beta-lactam	blaTEM-201_1	JX310327	ampicillin
-beta-lactam	blaTEM-205_1	KC900516	ampicillin
-beta-lactam	blaTEM-206_1	KC783461	ampicillin
-beta-lactam	blaTEM-208_1	KC865667	ampicillin
-beta-lactam	blaTEM-209_1	KF240808	ampicillin
-beta-lactam	blaTEM-213_1	LJEE02000034	ampicillin
-beta-lactam	blaTEM-55_1	DQ286729	ampicillin
-beta-lactam	blaTEM-57_1	FJ405211	ampicillin
-beta-lactam	blaTEM-68_1	AJ239002	ampicillin
-beta-lactam	blaTEM-70_1	AF188199	ampicillin
-beta-lactam	blaTEM-71_1	AF203816	ampicillin
-beta-lactam	blaTEM-72_1	AF157553	ampicillin
-beta-lactam	blaTEM-90_1	AF351241	ampicillin
-beta-lactam	blaTEM-95_1	AJ308558	ampicillin
-beta-lactam	blaTEM-96_1	AY092401	ampicillin
-beta-lactam	blaTEM-97_1	AF397067	ampicillin
-beta-lactam	blaTEM-98_1	AF397068	ampicillin
-beta-lactam	blaTEM-99_1	AF397066	ampicillin
-beta-lactam	blaTLA-1_1	AF148067	ampicillin
-beta-lactam	blaTRU_1	EU046614	ampicillin
-beta-lactam	blaTUS-1_1	AF441287	ampicillin
-beta-lactam	blaZ_3	CP000732	ampicillin
-beta-lactam	blaZ_30	JGUQ01000012	ampicillin
-beta-lactam	blaZ_31	JIFU01000008	ampicillin
-beta-lactam	blaZ_32	JINH01000005	ampicillin
-beta-lactam	blaZ_33	JIXQ01000012	ampicillin
-beta-lactam	blaZ_34	JJAO01000008	ampicillin
-beta-lactam	blaZ_35	JIVZ01000012	ampicillin
-beta-lactam	blaZ_36	JITV01000006	ampicillin
-beta-lactam	blaZ_37	JIFD01000012	ampicillin
-beta-lactam	blaZ_38	NZ_JEMM01000040	ampicillin
-beta-lactam	blaZ_39	JHTU01000073	ampicillin
-beta-lactam	blaZEG-1_1	AY265891	ampicillin
-beta-lactam	cfxA_1	U38243	ampicillin
-beta-lactam	cfxA2_1	AF504914	ampicillin
-beta-lactam	cfxA3_1	AF472622	ampicillin
-beta-lactam	cfxA4_1	AY769933	ampicillin
-beta-lactam	cfxA5_1	AY769934	ampicillin
-beta-lactam	cfxA6_1	GQ342996	ampicillin
-beta-lactam	cphA1_1	AY261379	ampicillin
-beta-lactam	cphA1_2	AY261377	ampicillin
-beta-lactam	cphA1_3	AY261378	ampicillin
-beta-lactam	cphA1_4	AY261376	ampicillin
-beta-lactam	cphA1_7	X57102	ampicillin
-beta-lactam	cphA2_6	AHU60294	ampicillin
-beta-lactam	cphA4_1	AY227050	ampicillin
-beta-lactam	cphA5_1	AY227051	ampicillin
-beta-lactam	cphA6_1	AY227052	ampicillin
-beta-lactam	cphA7_1	AY227053	ampicillin
-beta-lactam	cphA8_1	AY261375	ampicillin
-beta-lactam	hugA_1	AF324468	ampicillin
-beta-lactam	imiH_1	AJ548797	ampicillin
-beta-lactam	imiS_1	Y10415	ampicillin
 beta-lactam	penA_1	AF515059	ampicillin
-beta-lactam	blaSPU-1_1	GQ919044	ampicilin,ceftriaxone
-beta-lactam	blaSRT-1_1	AB008454	ampicilin,ceftriaxone
-beta-lactam	blaSRT-2_1	AY524276	ampicilin,ceftriaxone
-beta-lactam	blaSST-1_1	AB008455	ampicilin,ceftriaxone
-beta-lactam	blaLAP-1_1	EF026092	ampicillin
-beta-lactam	blaLAP-2_1	EU159120	ampicillin
+beta-lactam	POM-1_1	GU002295	ampicillin,amoxicillin/clavulanic acid,cefoxitin,ceftriaxone,meropenem
 colistin	mcr-1.1_1	KP347127	colistin
 colistin	mcr-1.2_1	KX236309	colistin
 colistin	mcr-1.3_1	KU934208	colistin
@@ -2311,7 +2311,7 @@ colistin	mcr-3.23_1	NG060583	colistin
 colistin	mcr-3.25_1	NG060585	colistin
 colistin	mcr-4.5_1	MG822664	colistin
 colistin	mcr-8_1	MG736312	colistin
-colistin	mcr-9_1	NZ_NAAN01000063.1	None
+colistin	mcr-9_1	NZ_NAAN01000063.1	
 fosfomycin	fosB1_1	CP001903	fosfomycin
 fosfomycin	fosX_1	AP010904	fosfomycin
 fosfomycin	fos_1	ACCV01000052	fosfomycin
@@ -2526,8 +2526,8 @@ macrolide	mph(E)_2	JF769133	erythromycin,azithromycin
 macrolide	vga(D)_1	GQ205627	virginiamycin
 macrolide	vga(C)_1	FN806792	virginiamycin
 macrolide	vga(E)_1	FR772051	virginiamycin
-macrolide	lsa(A)_1	AY225127	lincomycin
-macrolide	lsa(A)_3	AY737526	lincomycin
+macrolide	lsa(A)_1	AY225127	lincomycin,clindamycin
+macrolide	lsa(A)_3	AY737526	lincomycin,clindamycin
 macrolide	erm(W)_1	D14532	lincomycin
 macrolide	cfr_1	AM408573	clindamycin
 macrolide	cfr_2	AJ879565	clindamycin
@@ -2572,6 +2572,7 @@ macrolide	mdf(A)_1	Y08743	erythromycin,azithromycin,lincomycin,tetracycline
 macrolide	mdt(A)_1	X92946	erythromycin,azithromycin,lincomycin,tetracycline
 macrolide	mre(A)_1	U92073	erythromycin,azithromycin
 macrolide	cmr_1	U43535	
+macrolide	lsa(E)_1	JX560992	lincomycin,clindamycin
 nitroimidazole	nimA_1	X71444	nitroimidazole
 nitroimidazole	nimB_1	X71443	nitroimidazole
 nitroimidazole	nimC_1	X76948	nitroimidazole

--- a/staramr/databases/resistance/data/info.ini
+++ b/staramr/databases/resistance/data/info.ini
@@ -1,3 +1,3 @@
 [Versions]
-pointfinder_gene_drug_version = 072621.2
-resfinder_gene_drug_version = 072621
+pointfinder_gene_drug_version = 070623
+resfinder_gene_drug_version = 072423


### PR DESCRIPTION
Noting here that the change in the ARG drug key from "salmonella acrB 717" to "salmonella acrB 171" might be a typo and worth confirming.