### PR TITLE
fix: preserve Start/End as int after concat with negative entries (fixes #241)

### DIFF
--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -265,6 +265,12 @@ class AMRDetectionSummary:
             resistance_frame = resistance_frame.sort_values(['Isolate ID', 'Data Type', 'Gene'])
 
         if resistance_frame is not None:
+            # Restore Start/End to int after concats that may upcast to float (e.g. with negative_entries)
+            for col in ['Start', 'End']:
+                if col in resistance_frame.columns:
+                    resistance_frame[col] = pd.to_numeric(
+                        resistance_frame[col], errors='coerce'
+                    ).astype(pd.Int64Dtype())
             resistance_frame = resistance_frame.fillna("")
 
         return resistance_frame


### PR DESCRIPTION
Closes #241

When concatenating resistance_frame with negative_entries (which have no Start/End values), pandas upcasts integer columns to float, causing Start/End to display as 100.0 instead of 100.

Restore Start/End to Int64 (nullable integer) before fillna so integer positions are preserved in the output.

Made with [Cursor](https://cursor.com)