### PR TITLE
STRY0020310: Modify StarAMR so that Start and End Positions are not Converted From Integers to Floats in the Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fixed a problem where sometimes integers in the output (ex: start and end positions) would be converted to floats. [PR #243](https://github.com/phac-nml/staramr/pull/243)
+
 # Version 0.12.1
 
 - Updating Biopython minimum version to v.1.86 in setup.py file. [PR #239](https://github.com/phac-nml/staramr/pull/239)

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -28,25 +28,18 @@ class AMRDetectionSummary:
 
         if resfinder_dataframe is not None:
             self._resfinder_dataframe = resfinder_dataframe.astype(pd.StringDtype())
-        else:
-            self._resfinder_dataframe = None
 
         if plasmidfinder_dataframe is not None:
             self._plasmidfinder_dataframe = plasmidfinder_dataframe.astype(pd.StringDtype())
-        else:
-            self._plasmidfinder_dataframe = None
 
         if mlst_dataframe is not None:
             self._mlst_dataframe = mlst_dataframe.astype(pd.StringDtype())
-        else:
-            self._mlst_dataframe = None
 
         if pointfinder_dataframe is not None:
             self._has_pointfinder = True
             self._pointfinder_dataframe = pointfinder_dataframe.astype(pd.StringDtype())
         else:
             self._has_pointfinder = False
-            self._pointfinder_dataframe = None
 
         self._quality_module_dataframe=quality_module_dataframe
 

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -25,15 +25,29 @@ class AMRDetectionSummary:
         :param pointfinder_dataframe: The pd.DataFrame containing the PointFinder results.
         """
         self._names = [path.splitext(path.basename(x))[0] for x in files]
-        self._resfinder_dataframe = resfinder_dataframe
-        self._plasmidfinder_dataframe = plasmidfinder_dataframe
-        self._mlst_dataframe = mlst_dataframe
+
+        if resfinder_dataframe is not None:
+            self._resfinder_dataframe = resfinder_dataframe.astype(pd.StringDtype())
+        else:
+            self._resfinder_dataframe = None
+
+        if plasmidfinder_dataframe is not None:
+            self._plasmidfinder_dataframe = plasmidfinder_dataframe.astype(pd.StringDtype())
+        else:
+            self._plasmidfinder_dataframe = None
+
+        if mlst_dataframe is not None:
+            self._mlst_dataframe = mlst_dataframe.astype(pd.StringDtype())
+        else:
+            self._mlst_dataframe = None
+
         if pointfinder_dataframe is not None:
             self._has_pointfinder = True
-            self._pointfinder_dataframe = pointfinder_dataframe
-
+            self._pointfinder_dataframe = pointfinder_dataframe.astype(pd.StringDtype())
         else:
             self._has_pointfinder = False
+            self._pointfinder_dataframe = None
+
         self._quality_module_dataframe=quality_module_dataframe
 
     def _compile_results(self, resistance_frame: DataFrame) -> DataFrame:

--- a/staramr/results/AMRDetectionSummary.py
+++ b/staramr/results/AMRDetectionSummary.py
@@ -28,18 +28,25 @@ class AMRDetectionSummary:
 
         if resfinder_dataframe is not None:
             self._resfinder_dataframe = resfinder_dataframe.astype(pd.StringDtype())
+        else:
+            self._resfinder_dataframe = None
 
         if plasmidfinder_dataframe is not None:
             self._plasmidfinder_dataframe = plasmidfinder_dataframe.astype(pd.StringDtype())
+        else:
+            self._plasmidfinder_dataframe = None
 
         if mlst_dataframe is not None:
             self._mlst_dataframe = mlst_dataframe.astype(pd.StringDtype())
+        else:
+            self._mlst_dataframe = None
 
         if pointfinder_dataframe is not None:
             self._has_pointfinder = True
             self._pointfinder_dataframe = pointfinder_dataframe.astype(pd.StringDtype())
         else:
             self._has_pointfinder = False
+            self._pointfinder_dataframe = None
 
         self._quality_module_dataframe=quality_module_dataframe
 

--- a/staramr/tests/integration/detection/test_AMRDetection.py
+++ b/staramr/tests/integration/detection/test_AMRDetection.py
@@ -1120,6 +1120,14 @@ class AMRDetectionIT(unittest.TestCase):
         self.assertEqual(expected_records2['16S_rrsD'].seq.upper(), records['16S-rrsD_1_CP049983.1'].seq.upper(),
                          "records don't match")
 
+        detailed_summary_results = amr_detection.get_detailed_summary_results()
+        resistance = detailed_summary_results[detailed_summary_results['Data'] == "blaIMP-42"]
+
+        self.assertEqual(resistance['%Identity'].iloc[0], '99.73', msg='Wrong pid')
+        self.assertEqual(resistance['%Overlap'].iloc[0], '100.0', msg='Wrong overlap')
+        self.assertEqual(resistance['Start'].iloc[0], '4381', msg='Wrong start')
+        self.assertEqual(resistance['End'].iloc[0], '5121', msg='Wrong end')
+
     def testResfinderExcludeNonMatches(self):
         amr_detection = AMRDetectionResistance(self.resfinder_database, self.resfinder_drug_table,
                                                self.cge_drug_table, self.blast_handler,

--- a/staramr/tests/integration/detection/test_AMRDetectionPlasmid.py
+++ b/staramr/tests/integration/detection/test_AMRDetectionPlasmid.py
@@ -158,8 +158,8 @@ class AMRDetectionPlasmid(unittest.TestCase):
         plasmid_type = detailed_summary_results[detailed_summary_results['Data'] == "rep1"]
         self.assertEqual(len(plasmid_type.index), 1, 'Wrong number of results detected')
         self.assertEqual(plasmid_type['Predicted Phenotype'].iloc[0], '', msg='Wrong predicted phenotype')
-        self.assertAlmostEqual(plasmid_type['%Identity'].iloc[0], 100.00, places=2, msg='Wrong pid')
-        self.assertAlmostEqual(plasmid_type['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
+        self.assertEqual(plasmid_type['%Identity'].iloc[0], '100.0', msg='Wrong pid')
+        self.assertEqual(plasmid_type['%Overlap'].iloc[0], '100.0', msg='Wrong overlap')
         self.assertEqual(plasmid_type['Accession'].iloc[0], 'AY357120', msg='Wrong accession')
         self.assertEqual(plasmid_type['HSP Length/Total Length'].iloc[0], '1491/1491', msg='Wrong lengths')
         self.assertEqual(plasmid_type['Data Type'].iloc[0], 'Plasmid', msg='Wrong data type')
@@ -167,8 +167,8 @@ class AMRDetectionPlasmid(unittest.TestCase):
         res_type = detailed_summary_results[detailed_summary_results['Data'] == "tet(47)"]
         self.assertEqual(len(res_type.index), 1, 'Wrong number of results detected')
         self.assertEqual(res_type['Predicted Phenotype'].iloc[0], 'tetracycline', msg='Wrong predicted phenotype')
-        self.assertAlmostEqual(res_type['%Identity'].iloc[0], 100.00, places=2, msg='Wrong pid')
-        self.assertAlmostEqual(res_type['%Overlap'].iloc[0], 100.00, places=2, msg='Wrong overlap')
+        self.assertEqual(res_type['%Identity'].iloc[0], '100.0', msg='Wrong pid')
+        self.assertEqual(res_type['%Overlap'].iloc[0], '100.0', msg='Wrong overlap')
         self.assertEqual(res_type['Accession'].iloc[0], 'KR857681', msg='Wrong accession')
         self.assertEqual(res_type['HSP Length/Total Length'].iloc[0], '1248/1248', msg='Wrong lengths')
         self.assertEqual(res_type['Data Type'].iloc[0], 'Resistance', msg='Wrong data type')


### PR DESCRIPTION
**Description**

As a data analyst, I would like the Start and End positions reported in the output summary files of StarAMR to be represented as integers instead of floats.

**Acceptance Criteria**

- StarAMR reports the Start and End positions in all output summary files in integer representation (ex: 100) and not in float representation (ex: 100.0).

**Notes**

Fixes #241

development:
```
rm -r out/; staramr search -o out staramr/tests/integration/data/16S-rc_gyrA-rc_beta-lactam.fsa
cat out/detailed_summary.tsv
```
```
Isolate ID      Data    Data Type       Predicted Phenotype     CGE Predicted Phenotype %Identity       %Overlap        HSP Length/Total Length Contig    Start   End     Accession
16S-rc_gyrA-rc_beta-lactam      ST- (-) MLST
16S-rc_gyrA-rc_beta-lactam      None    Plasmid
16S-rc_gyrA-rc_beta-lactam      blaIMP-42       Resistance      ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone, meropenem      Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefepime, Cefixime, Cefotaxime, Cefoxitin, Ceftazidime, Ertapenem, Imipenem, Meropenem, Piperacillin, Piperacillin+Tazobactam     99.73   100.0   741/741 16S_rrsD        4381.0  5121.0  AB753456
```

fix:
```
rm -r out/; staramr search -o out staramr/tests/integration/data/16S-rc_gyrA-rc_beta-lactam.fsa
cat out/detailed_summary.tsv
```
```
Isolate ID      Data    Data Type       Predicted Phenotype     CGE Predicted Phenotype %Identity       %Overlap        HSP Length/Total Length Contig    Start   End     Accession
16S-rc_gyrA-rc_beta-lactam      ST- (-) MLST
16S-rc_gyrA-rc_beta-lactam      None    Plasmid
16S-rc_gyrA-rc_beta-lactam      blaIMP-42       Resistance      ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone, meropenem      Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefepime, Cefixime, Cefotaxime, Cefoxitin, Ceftazidime, Ertapenem, Imipenem, Meropenem, Piperacillin, Piperacillin+Tazobactam     99.73   100.0   741/741 16S_rrsD        4381    5121    AB753456
```